### PR TITLE
Fix syntax error in reset_simulator AppleScript

### DIFF
--- a/Supporting Files/CI/reset_simulator
+++ b/Supporting Files/CI/reset_simulator
@@ -50,7 +50,7 @@ tell application "System Events"
 		tell menu bar 1
 			tell menu bar item "iOS Simulator"
 				tell menu "iOS Simulator"
-					click menu item "Reset Content and Settings‚Ä¶"
+					click menu item "Reset Content and Settings…"
 				end tell
 			end tell
 		end tell

--- a/Supporting Files/CI/reset_simulator
+++ b/Supporting Files/CI/reset_simulator
@@ -37,7 +37,7 @@ tell application "System Events"
 	-- Sometimes Applescript can time out trying to talk to the Simulator
 	-- (e.g. when being reset repeatedly during CI runs),
 	-- so we force quit the Simulator to start
-	if "iPhone Simulator" is in name of processes
+	if "iPhone Simulator" is in name of processes then
 		do shell script "killall \"iPhone Simulator\" 2> /dev/null"
 		delay 1.0
 	end if


### PR DESCRIPTION
Adds a missing "then" at the end of an if statement.  You'd think
this would cause a consistent error whenever we tried to use the
script, but AppleScript tries to be "forgiving."
