### PR TITLE
Rewrites the reset_simulator script as a bash script

### DIFF
--- a/Supporting Files/CI/reset_simulator
+++ b/Supporting Files/CI/reset_simulator
@@ -1,72 +1,27 @@
-#!/usr/bin/osascript
+#!/bin/bash
 
-(*
-For details and documentation:
-http://github.com/inkling/Subliminal
+# For details and documentation:
+# http://github.com/inkling/Subliminal
 
-Copyright 2013 Inkling Systems, Inc.
+# Copyright 2013 Inkling Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+# Deletes all applications from the iPhone Simulator and resets its settings.
 
-  http://www.apache.org/licenses/LICENSE-2.0
+killall "iPhone Simulator" &> /dev/null
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*)
+rm -rf "$HOME/Library/Application Support/iPhone Simulator"
 
-(*
-Deletes all applications from the iPhone Simulator and resets its settings.
-*)
-
--- Ensure GUI scripting is enabled
-tell application "Finder"
-	set scriptDir to container of (path to me) as text
-end tell
-
-set enableGUIScriptingScript to (scriptDir & "enable_GUI_scripting")
-set GUIScriptingEnabled to (run script (enableGUIScriptingScript as alias))
-if not GUIScriptingEnabled then return false
-
--- Reset simulator
-tell application "System Events"
-	-- Sometimes Applescript can time out trying to talk to the Simulator
-	-- (e.g. when being reset repeatedly during CI runs),
-	-- so we force quit the Simulator to start
-	if "iPhone Simulator" is in name of processes then
-		do shell script "killall \"iPhone Simulator\" 2> /dev/null"
-		delay 1.0
-	end if
-
-	tell application "iPhone Simulator"
-		activate
-	end tell
-
-	tell process "iPhone Simulator"
-		tell menu bar 1
-			tell menu bar item "iOS Simulator"
-				tell menu "iOS Simulator"
-					click menu item "Reset Content and Settings…"
-				end tell
-			end tell
-		end tell
-		tell window 1
-			click button "Reset"
-		end tell
-	end tell
-end tell
-
--- Ensure that simulator flushes settings
--- such as the registry of installed applications.
--- This is necessary when an application's bundle identifier changes.
-tell application "iPhone Simulator"
-	quit
-	delay 1.0
-	activate
-end tell
-
-return true
+XCODE_PATH=`xcode-select --print-path`
+open "$XCODE_PATH/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app"

--- a/Supporting Files/CI/reset_simulator
+++ b/Supporting Files/CI/reset_simulator
@@ -25,3 +25,5 @@ rm -rf "$HOME/Library/Application Support/iPhone Simulator"
 
 XCODE_PATH=`xcode-select --print-path`
 open "$XCODE_PATH/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app"
+
+sleep 5

--- a/Supporting Files/CI/set_simulator_device
+++ b/Supporting Files/CI/set_simulator_device
@@ -27,3 +27,5 @@ defaults write com.apple.iPhoneSimulator SimulateDevice $1
 
 XCODE_PATH=`xcode-select --print-path`
 open "$XCODE_PATH/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app"
+
+sleep 5

--- a/Supporting Files/CI/set_simulator_device
+++ b/Supporting Files/CI/set_simulator_device
@@ -1,58 +1,29 @@
-#!/usr/bin/osascript
+#!/bin/bash
 
-(*
-For details and documentation:
-http://github.com/inkling/Subliminal
+# For details and documentation:
+# http://github.com/inkling/Subliminal
+#
+# Copyright 2013 Inkling Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Copyright 2013 Inkling Systems, Inc.
+# Sets the simulator's device to the specified type.
+#
+# Acceptable types are listed in the iPhone Simulator's "Hardware -> Device" menu.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+killall "iPhone Simulator" &> /dev/null
 
-	http://www.apache.org/licenses/LICENSE-2.0
+defaults write com.apple.iPhoneSimulator SimulateDevice $1
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*)
-
-(*
-Sets the simulator's device to the specified type.
-
-Acceptable types are listed in the iPhone Simulator's "Hardware -> Device" menu.
-*)
-
-on run argv
-	-- Ensure GUI scripting is enabled
-	tell application "Finder"
-		set scriptDir to container of (path to me) as text
-	end tell
-	
-	set enableGUIScriptingScript to (scriptDir & "enable_GUI_scripting")
-	set GUIScriptingEnabled to (run script (enableGUIScriptingScript as alias))
-	if not GUIScriptingEnabled then return false
-	
-	-- Select simulator device type
-	set deviceType to item 1 of argv
-	tell application "iPhone Simulator"
-		activate
-	end tell
-	
-	tell application "System Events"
-		tell process "iPhone Simulator"
-			tell menu bar 1
-				tell menu "Hardware" of menu bar item "Hardware"
-					tell menu "Device" of menu item "Device"
-						click menu item deviceType
-					end tell
-				end tell
-			end tell
-		end tell
-	end tell
-	
-	delay 0.1
-	return true
-end run
+XCODE_PATH=`xcode-select --print-path`
+open "$XCODE_PATH/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app"

--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -298,7 +298,8 @@ if [[ -n "$SIM_DEVICE" ]]; then
 
 	# Set the simulator's device type
 	echo "\nSetting simulator device type..."
-	if [ `osascript "$SCRIPT_DIR/set_simulator_device" "$SIM_DEVICE"` ]; then
+	"$SCRIPT_DIR/set_simulator_device" "$SIM_DEVICE"
+	if [ $? -eq 0 ]; then
 		echo "Successfully set simulator device type."
 	else
 		echo "\n\nERROR: Could not set the simulator's device type."

--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -288,7 +288,8 @@ if [[ -n "$SIM_DEVICE" ]]; then
 	SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 
 	echo "\nResetting simulator content and settings..."
-	if [ `osascript "$SCRIPT_DIR/reset_simulator"` ]; then
+	"$SCRIPT_DIR/reset_simulator"
+	if [ $? -eq 0 ]; then
 		echo "Successfully reset iOS Simulator."
 	else
 		echo "\n\nERROR: Could not reset the simulator."
@@ -351,7 +352,8 @@ if [[ -n "$SIM_DEVICE" ]]; then
 	# due to the risk of collision
 	if [[ -n "$REPLACEMENT_BUNDLE_ID" ]]; then
 		echo "\nResetting simulator content and settings again because bundle identifier was replaced..."
-		if [ `osascript "$SCRIPT_DIR/reset_simulator"` ]; then
+		"$SCRIPT_DIR/reset_simulator"
+		if [ $? -eq 0 ]; then
 			echo "Successfully reset iOS Simulator."
 		else
 			echo "\nERROR: Could not reset the simulator."


### PR DESCRIPTION
We just keep having trouble with the AppleScript form of this
script.  So instead of using AppleScript to hit the simulator's
Reset Contents and Settings menu item we'll just blow away
everything the simulator stored in Application Support.
