### PR TITLE
Updates the README with instructions how to get the example app running

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ screencast [here](https://vimeo.com/67765518))
 * Read the FAQ [here](#faq), and find support [@subliminaltest](https://twitter.com/subliminaltest) 
 and on [Stack Overflow](http://stackoverflow.com/questions/tagged/subliminal)
 
+Running the Example App
+-----------------------
+
+1. Clone the Subliminal repo: `git clone git@github.com:inkling/Subliminal.git`
+2. cd into the directory: `cd Subliminal`
+3. If you haven't already, setup Subliminal: `rake install`
+4. Open the Example project: `open Example/SubliminalTest.xcodeproj`
+5. Run the tests: Using the `Integration Tests` scheme, choose Product > Profile (⌘+I).
+6. Under the User Templates, choose Subliminal
+
 Installing Subliminal
 ---------------------
 
@@ -434,17 +444,6 @@ FAQ
 		to break immediately after launch, you may find it useful to give yourself 
 		time to attach the debugger by setting `-[SLTestController shouldWaitToStartTesting]` 
 		to `YES`.
-
-Running the Example App
------------------------
-
-1. Clone the Subliminal repo: `git clone git@github.com:inkling/Subliminal.git`
-2. cd into the directory: `cd Subliminal`
-3. Create git submodules: `git submodule update --init`
-4. Setup Subliminal: `rake install`
-5. Open the Example project: `open Example/SubliminalTest.xcodeproj`
-6. Run the tests: Using the `Integration Tests` scheme, choose Product > Profile (⌘+I).
-7. Under the User Templates, choose Subliminal
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ FAQ
 		time to attach the debugger by setting `-[SLTestController shouldWaitToStartTesting]` 
 		to `YES`.
 
-Running the Example app
+Running the Example App
 -----------------------
 
 1. Clone the Subliminal repo: `git clone git@github.com:inkling/Subliminal.git`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ How to Get Started
 ------------------
 
 * [Download Subliminal](https://github.com/inkling/Subliminal/zipball/master) 
-and try out the included example app
+and try out the included example app. Instructions for running the saple app are [here](##Running the Example app)
 * Install Subliminal and write your first test in just 10 minutes (guide below, 
 screencast [here](https://vimeo.com/67765518))
 * Read the FAQ [here](##FAQ), and find support [@subliminaltest](https://twitter.com/subliminaltest) 
@@ -434,6 +434,17 @@ FAQ
 		to break immediately after launch, you may find it useful to give yourself 
 		time to attach the debugger by setting `-[SLTestController shouldWaitToStartTesting]` 
 		to `YES`.
+
+Running the Example app
+-----------------------
+
+1. Clone the Subliminal repo: `git clone git@github.com:inkling/Subliminal.git`
+2. cd into the directory: `cd Subliminal`
+3. Create git submodules: `git submodule update --init`
+4. Setup Subliminal: `rake install`
+5. Open the Example project: `open Example/SubliminalTest.xcodeproj`
+6. Run the tests: Using the `Integration Tests` scheme, choose Product > Profile (⌘+I).
+7. Under the User Templates, choose Subliminal
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ How to Get Started
 ------------------
 
 * [Download Subliminal](https://github.com/inkling/Subliminal/zipball/master) 
-and try out the included example app. Instructions for running the saple app are [here](##Running the Example app)
+and try out the included example app. Instructions for running the example app are [here](#running-the-example-app)
 * Install Subliminal and write your first test in just 10 minutes (guide below, 
 screencast [here](https://vimeo.com/67765518))
-* Read the FAQ [here](##FAQ), and find support [@subliminaltest](https://twitter.com/subliminaltest) 
+* Read the FAQ [here](#faq), and find support [@subliminaltest](https://twitter.com/subliminaltest) 
 and on [Stack Overflow](http://stackoverflow.com/questions/tagged/subliminal)
 
 Installing Subliminal


### PR DESCRIPTION
As a prospective user of Subliminal, it was important to me to check out the example app and see how things worked. Unfortunately, running the example app wasn't exactly turnkey. 

Absent it being easier to setup, I added instructions to the README about how to get it working. Since the errors you run into without installing the submodules or running the Rake task don't prompt obvious fixes, I think having instructions is important. 

I wasn't sure about where to place the instructions; I ended up putting them towards the end and linking to them from the "Getting Started" section (unrelated, I also fixed the link from Getting Started to the FAQ)

Very excited about Subliminal :+1: Sorry I was kind of out of it when I asked you the web view question on Wednesday -- coffee had worn off by that point
