### PR TITLE
Cast `timeout` param of SLAssertTrueWithTimeout to NSTimeInterval to avoid warning

### DIFF
--- a/Example/Integration Tests/STLoginTest.m
+++ b/Example/Integration Tests/STLoginTest.m
@@ -61,7 +61,7 @@
     [UIAElement(_submitButton) tap];
 
     // using -isInvalidOrInvisible allows the spinner not to exist when we start waiting
-    SLAssertTrueWithTimeout([UIAElement(_loginSpinner) isInvalidOrInvisible], 3.0, @"Log-in was not successful.");
+    SLAssertTrueWithTimeout([UIAElement(_loginSpinner) isInvalidOrInvisible], 3, @"Log-in was not successful.");
     
     NSString *successMessage = [NSString stringWithFormat:@"Hello, %@!", username];
     SLAssertTrue([UIAElement([SLElement elementWithAccessibilityLabel:successMessage]) isValid], @"Log-in did not succeed.");

--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -437,7 +437,7 @@
     \
     if (!SLWaitUntilTrue(expression, timeout)) { \
         NSString *reason = [NSString stringWithFormat:@"\"%@\" did not become true within %g seconds.%@", \
-        @(#expression), timeout, SLComposeString(@" ", failureDescription, ##__VA_ARGS__)]; \
+        @(#expression), (NSTimeInterval)timeout, SLComposeString(@" ", failureDescription, ##__VA_ARGS__)]; \
         @throw [NSException exceptionWithName:SLTestAssertionFailedException reason:reason userInfo:nil]; \
     } \
 } while (0)


### PR DESCRIPTION
I noticed that if you passed just `3` to `SLAssertTrueWithTimeout` that you would get a warning about it not being a double. Since code like `[NSDate dateWithTimeIntervalSinceNow:3]` doesn't require an explicit 3.0, it seems reasonable to not require it for the `SLAssertTrueWithTimeout` macro. 
