### PR TITLE
Aegolden/ios5 compat

### DIFF
--- a/Integration Tests/SLIntegrationTestsAppDelegate.m
+++ b/Integration Tests/SLIntegrationTestsAppDelegate.m
@@ -82,7 +82,7 @@
 
 - (void)verifyTerminalConnectionAndRunTests {
     // Wait for UIAutomation to evaluate our command
-    NSTimeInterval startupTimeout = 2.0;
+    NSTimeInterval startupTimeout = 5.0;
     NSDate *startDate = [NSDate date];
     while (![_terminalStartupResult isEqualToString:@"Hello world"]
            && [[NSDate date] timeIntervalSinceDate:startDate] < startupTimeout) {

--- a/Integration Tests/SLTestViewController.m
+++ b/Integration Tests/SLTestViewController.m
@@ -51,12 +51,6 @@ NSString *const SLTestCaseViewControllerClassNameKey = @"SLTestCaseViewControlle
     return NSStringFromClass(_test);
 }
 
-static NSString *TestCaseCellIdentifier = @"SLTestCaseCell";
-- (void)viewDidLoad {
-    [super viewDidLoad];
-    [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:TestCaseCellIdentifier];
-}
-
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 
@@ -83,8 +77,13 @@ static NSString *TestCaseCellIdentifier = @"SLTestCaseCell";
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    NSString *testCaseName = [_testCases objectAtIndex:indexPath.row];    
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:TestCaseCellIdentifier forIndexPath:indexPath];
+    NSString *testCaseName = [_testCases objectAtIndex:indexPath.row];
+
+    static NSString *TestCaseCellIdentifier = @"SLTestCaseCell";
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:TestCaseCellIdentifier];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:TestCaseCellIdentifier];
+    }
 
     cell.textLabel.text = testCaseName;
 

--- a/Integration Tests/SLTestsViewController.m
+++ b/Integration Tests/SLTestsViewController.m
@@ -49,12 +49,6 @@ NSString *const SLTestCasesKey = @"SLTestCasesKey";
     return @"Tests";
 }
 
-static NSString *TestCellIdentifier = @"SLTestCell";
-- (void)viewDidLoad {
-    [super viewDidLoad];
-    [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:TestCellIdentifier];
-}
-
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 
@@ -83,7 +77,11 @@ static NSString *TestCellIdentifier = @"SLTestCell";
 {
     Class testClass = [_tests objectAtIndex:indexPath.row];
 
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:TestCellIdentifier forIndexPath:indexPath];
+    static NSString *TestCellIdentifier = @"SLTestCell";
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:TestCellIdentifier];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:TestCellIdentifier];
+    }
 
     cell.textLabel.text = NSStringFromClass(testClass);
     

--- a/Integration Tests/Tests/SLDeviceTestViewController.xib
+++ b/Integration Tests/Tests/SLDeviceTestViewController.xib
@@ -2,16 +2,15 @@
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1552</int>
-		<string key="IBDocument.SystemVersion">12C3012</string>
+		<string key="IBDocument.SystemVersion">12D78</string>
 		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
+		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 			<string key="NS.object.0">2083</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBNSLayoutConstraint</string>
 			<string>IBProxyObject</string>
 			<string>IBUILabel</string>
 			<string>IBUIView</string>
@@ -74,6 +73,7 @@
 						<string key="NSFrame">{{153, 237}, {14, 29}}</string>
 						<reference key="NSSuperview" ref="191373211"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
@@ -170,70 +170,6 @@
 						<int key="objectID">1</int>
 						<reference key="object" ref="191373211"/>
 						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="803508320">
-								<reference key="firstItem" ref="898225440"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="783775318"/>
-								<int key="secondAttribute">4</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">8</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="345979933">
-								<reference key="firstItem" ref="898225440"/>
-								<int key="firstAttribute">9</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">9</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">5</int>
-								<float key="scoringTypeFloat">22</float>
-								<int key="contentType">2</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="927862842">
-								<reference key="firstItem" ref="898225440"/>
-								<int key="firstAttribute">9</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="783775318"/>
-								<int key="secondAttribute">9</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">2</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="672332717">
-								<reference key="firstItem" ref="783775318"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">3</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">208</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">3</int>
-							</object>
 							<reference ref="898225440"/>
 							<reference ref="783775318"/>
 						</array>
@@ -261,26 +197,6 @@
 						<array class="NSMutableArray" key="children"/>
 						<reference key="parent" ref="191373211"/>
 					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">17</int>
-						<reference key="object" ref="927862842"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">18</int>
-						<reference key="object" ref="345979933"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">19</int>
-						<reference key="object" ref="672332717"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">20</int>
-						<reference key="object" ref="803508320"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -289,20 +205,8 @@
 				<string key="-2.CustomClassName">UIResponder</string>
 				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<array class="NSMutableArray" key="1.IBViewMetadataConstraints">
-					<reference ref="672332717"/>
-					<reference ref="927862842"/>
-					<reference ref="345979933"/>
-					<reference ref="803508320"/>
-				</array>
-				<string key="17.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="18.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="19.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="20.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<boolean value="NO" key="4.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
 				<string key="8.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<boolean value="NO" key="8.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
 				<object class="NSMutableAttributedString" key="8.notes">
 					<object class="NSMutableString" key="NSString">
 						<characters key="NS.bytes"/>
@@ -317,14 +221,6 @@
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">NSLayoutConstraint</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/NSLayoutConstraint.h</string>
-					</object>
-				</object>
 				<object class="IBPartialClassDescription">
 					<string key="className">SLDeviceTestViewController</string>
 					<string key="superclassName">SLTestCaseViewController</string>
@@ -361,7 +257,6 @@
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<bool key="IBDocument.UseAutolayout">YES</bool>
 		<string key="IBCocoaTouchPluginVersion">2083</string>
 	</data>
 </archive>

--- a/Integration Tests/Tests/SLElementDraggingTest.m
+++ b/Integration Tests/Tests/SLElementDraggingTest.m
@@ -42,6 +42,9 @@ static const CGFloat kBottomLabelYOffset = 0.2;
 }
 
 /// This test demonstrates simply that we can drag a view.
+/// It will also confirm that we can drag a scroll view
+/// despite UIAutomation reporting it not being tappable when running
+/// on the iPad 5.1 Simulator (though error messages are logged).
 - (void)testDraggingSimple {
     // Do not run this test on Travis, because even very simple scrolling tests
     // fail regularly on the Travis machines.  These tests seem to work fine in

--- a/Integration Tests/Tests/SLElementMatchingTestViewController.m
+++ b/Integration Tests/Tests/SLElementMatchingTestViewController.m
@@ -119,6 +119,10 @@
 
 @implementation SLElementMatchingTestViewController {
     UIView *_parentView, *_childView;
+
+    NSString *_testTableViewCellIdentifier;
+    Class _testTableViewCellClass;
+
     UIWebView *_webView;
     BOOL _webViewDidFinishLoad;
 
@@ -192,7 +196,6 @@
     }
 }
 
-static NSString *TestCellIdentifier = nil;
 - (void)viewDidLoad {
     [super viewDidLoad];
 
@@ -213,20 +216,18 @@ static NSString *TestCellIdentifier = nil;
     _childView.accessibilityLabel = @"childView";
 
     if (self.tableView) {
-        Class testCellClass;
         if ((self.testCase == @selector(testMatchingTableViewCellTextLabel)) ||
             (self.testCase == @selector(testMatchingTableViewHeader)) ||
             (self.testCase == @selector(testMatchingTableViewHeaderChildElements))) {
-            testCellClass = [UITableViewCell class];
+            _testTableViewCellClass = [UITableViewCell class];
         } else if ((self.testCase == @selector(testMatchingNonLabelTableViewCellChildElement)) ||
                    (self.testCase == @selector(testMatchingTableViewCellWithCombinedLabel)) ||
                    (self.testCase == @selector(testCannotMatchIndividualChildLabelsOfTableViewCell))) {
-            testCellClass = [SLElementMatchingTestCell class];
+            _testTableViewCellClass = [SLElementMatchingTestCell class];
         } else {
             NSAssert(NO, @"Table view loaded for unexpected test case: %@.", NSStringFromSelector(self.testCase));
         }
-        TestCellIdentifier = [NSString stringWithFormat:@"%@_%@", NSStringFromClass(testCellClass), NSStringFromSelector(self.testCase)];
-        [self.tableView registerClass:testCellClass forCellReuseIdentifier:TestCellIdentifier];
+        _testTableViewCellIdentifier = [NSString stringWithFormat:@"%@_%@", NSStringFromClass(_testTableViewCellClass), NSStringFromSelector(self.testCase)];
     }
 
     if (_webView) {
@@ -248,7 +249,10 @@ static NSString *TestCellIdentifier = nil;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:TestCellIdentifier forIndexPath:indexPath];
+    UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:_testTableViewCellIdentifier];
+    if (!cell) {
+        cell = [[_testTableViewCellClass alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:_testTableViewCellIdentifier];
+    }
 
     if ((self.testCase == @selector(testMatchingTableViewCellTextLabel)) ||
         (self.testCase == @selector(testMatchingTableViewHeader)) ||

--- a/Integration Tests/Tests/SLElementMatchingTestViewController.xib
+++ b/Integration Tests/Tests/SLElementMatchingTestViewController.xib
@@ -11,7 +11,6 @@
 			<string key="NS.object.0">2083</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBNSLayoutConstraint</string>
 			<string>IBProxyObject</string>
 			<string>IBUIButton</string>
 			<string>IBUISearchBar</string>
@@ -93,6 +92,7 @@
 						<string key="NSFrame">{{20, 167}, {280, 44}}</string>
 						<reference key="NSSuperview" ref="191373211"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -192,166 +192,6 @@
 						<int key="objectID">1</int>
 						<reference key="object" ref="191373211"/>
 						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="1006373865">
-								<reference key="firstItem" ref="191373211"/>
-								<int key="firstAttribute">6</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="741949669"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="123595670">
-								<reference key="firstItem" ref="741949669"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">5</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="30346705">
-								<reference key="firstItem" ref="741949669"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">3</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">167</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="690713233">
-								<reference key="firstItem" ref="191373211"/>
-								<int key="firstAttribute">6</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="678913373"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="419756468">
-								<reference key="firstItem" ref="678913373"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">5</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="391982807">
-								<reference key="firstItem" ref="678913373"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">3</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">99</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="488321961">
-								<reference key="firstItem" ref="678913373"/>
-								<int key="firstAttribute">11</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="741949669"/>
-								<int key="secondAttribute">11</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">2</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="633556730">
-								<reference key="firstItem" ref="21240452"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">5</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="813411520">
-								<reference key="firstItem" ref="21240452"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">3</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="833247996">
-								<reference key="firstItem" ref="21240452"/>
-								<int key="firstAttribute">6</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
 							<reference ref="21240452"/>
 							<reference ref="678913373"/>
 							<reference ref="741949669"/>
@@ -372,24 +212,7 @@
 					<object class="IBObjectRecord">
 						<int key="objectID">4</int>
 						<reference key="object" ref="678913373"/>
-						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="908349781">
-								<reference key="firstItem" ref="678913373"/>
-								<int key="firstAttribute">8</int>
-								<int key="relation">0</int>
-								<nil key="secondItem"/>
-								<int key="secondAttribute">0</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">43</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="678913373"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">1</int>
-							</object>
-						</array>
+						<array class="NSMutableArray" key="children"/>
 						<reference key="parent" ref="191373211"/>
 					</object>
 					<object class="IBObjectRecord">
@@ -398,64 +221,9 @@
 						<reference key="parent" ref="191373211"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">25</int>
-						<reference key="object" ref="833247996"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">26</int>
-						<reference key="object" ref="813411520"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">27</int>
-						<reference key="object" ref="633556730"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
 						<int key="objectID">30</int>
 						<reference key="object" ref="741949669"/>
 						<array class="NSMutableArray" key="children"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">35</int>
-						<reference key="object" ref="488321961"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">39</int>
-						<reference key="object" ref="391982807"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">40</int>
-						<reference key="object" ref="419756468"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">41</int>
-						<reference key="object" ref="908349781"/>
-						<reference key="parent" ref="678913373"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">42</int>
-						<reference key="object" ref="690713233"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">43</int>
-						<reference key="object" ref="30346705"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">45</int>
-						<reference key="object" ref="123595670"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">47</int>
-						<reference key="object" ref="1006373865"/>
 						<reference key="parent" ref="191373211"/>
 					</object>
 				</array>
@@ -466,43 +234,14 @@
 				<string key="-2.CustomClassName">UIResponder</string>
 				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<array key="1.IBViewMetadataConstraints">
-					<reference ref="833247996"/>
-					<reference ref="813411520"/>
-					<reference ref="633556730"/>
-					<reference ref="488321961"/>
-					<reference ref="391982807"/>
-					<reference ref="419756468"/>
-					<reference ref="690713233"/>
-					<reference ref="30346705"/>
-					<reference ref="123595670"/>
-					<reference ref="1006373865"/>
-				</array>
 				<string key="24.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<boolean value="NO" key="24.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-				<string key="25.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="26.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="27.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="30.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<boolean value="NO" key="30.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-				<string key="35.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="39.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<array key="4.IBViewMetadataConstraints">
-					<reference ref="908349781"/>
-				</array>
-				<boolean value="NO" key="4.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
 				<object class="NSMutableAttributedString" key="4.notes">
 					<object class="NSMutableString" key="NSString">
 						<characters key="NS.bytes"/>
 					</object>
 				</object>
-				<string key="40.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="41.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="42.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="43.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="45.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="47.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 			</dictionary>
 			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
 			<nil key="activeLocalization"/>
@@ -512,14 +251,6 @@
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">NSLayoutConstraint</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/NSLayoutConstraint.h</string>
-					</object>
-				</object>
 				<object class="IBPartialClassDescription">
 					<string key="className">SLElementMatchingTestViewController</string>
 					<string key="superclassName">SLTestCaseViewController</string>
@@ -566,7 +297,6 @@
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<bool key="IBDocument.UseAutolayout">YES</bool>
 		<string key="IBCocoaTouchPluginVersion">2083</string>
 	</data>
 </archive>

--- a/Integration Tests/Tests/SLElementStateTest.m
+++ b/Integration Tests/Tests/SLElementStateTest.m
@@ -106,6 +106,24 @@
     SLAssertTrue([UIAElement(_testElement) isTappable], @"Element should be tappable if hitpoint is not null.");
 }
 
+- (void)testScrollViewsAreNotTappableOnIPad5_x {
+    SLElement *scrollView = [SLElement elementWithAccessibilityIdentifier:@"scroll view"];
+    if ((kCFCoreFoundationVersionNumber <= kCFCoreFoundationVersionNumber_iOS_5_1) &&
+        ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)) {
+        SLAssertFalse([UIAElement(scrollView) isTappable],
+                      @"UIAutomation should report scroll views as not tappable on iPads running iOS 5.x.");
+    } else {
+        SLAssertTrue([UIAElement(scrollView) isTappable],
+                     @"UIAutomation should otherwise report scroll views as tappable.");
+    }
+}
+
+- (void)testScrollViewChildElementsAreTappableEvenOnIPad5_x {
+    SLButton *scrollViewButton = [SLButton elementWithAccessibilityLabel:@"Button"];
+    SLAssertTrue([UIAElement(scrollViewButton) isTappable],
+                 @"UIAutomation should correctly report scroll view child elements as tappable regardless of platform.");
+}
+
 // UIAutomation does not throw an exception when asked to access a user interface
 // element, so long as that access does not involve simulating user interaction
 // with the element. Contrast -[SLElementTapTest testUserInteractionRequiresTappability].

--- a/Integration Tests/Tests/SLElementStateTestScrollViewCases.xib
+++ b/Integration Tests/Tests/SLElementStateTestScrollViewCases.xib
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
+	<data>
+		<int key="IBDocument.SystemTarget">1552</int>
+		<string key="IBDocument.SystemVersion">12E55</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.39</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			<string key="NS.object.0">2083</string>
+		</object>
+		<array key="IBDocument.IntegratedClassDependencies">
+			<string>IBProxyObject</string>
+			<string>IBUIButton</string>
+			<string>IBUIScrollView</string>
+			<string>IBUIView</string>
+		</array>
+		<array key="IBDocument.PluginDependencies">
+			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+		</array>
+		<object class="NSMutableDictionary" key="IBDocument.Metadata">
+			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
+			<integer value="1" key="NS.object.0"/>
+		</object>
+		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
+			<object class="IBProxyObject" id="372490531">
+				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBProxyObject" id="975951072">
+				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBUIView" id="191373211">
+				<reference key="NSNextResponder"/>
+				<int key="NSvFlags">274</int>
+				<array class="NSMutableArray" key="NSSubviews">
+					<object class="IBUIScrollView" id="111704902">
+						<reference key="NSNextResponder" ref="191373211"/>
+						<int key="NSvFlags">274</int>
+						<array class="NSMutableArray" key="NSSubviews">
+							<object class="IBUIButton" id="5460194">
+								<reference key="NSNextResponder" ref="111704902"/>
+								<int key="NSvFlags">292</int>
+								<string key="NSFrame">{{20, 20}, {73, 44}}</string>
+								<reference key="NSSuperview" ref="111704902"/>
+								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView"/>
+								<string key="NSReuseIdentifierKey">_NS:9</string>
+								<bool key="IBUIOpaque">NO</bool>
+								<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+								<int key="IBUIContentHorizontalAlignment">0</int>
+								<int key="IBUIContentVerticalAlignment">0</int>
+								<int key="IBUIButtonType">1</int>
+								<string key="IBUINormalTitle">Button</string>
+								<object class="NSColor" key="IBUIHighlightedTitleColor">
+									<int key="NSColorSpace">3</int>
+									<bytes key="NSWhite">MQA</bytes>
+								</object>
+								<object class="NSColor" key="IBUINormalTitleColor">
+									<int key="NSColorSpace">1</int>
+									<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
+								</object>
+								<object class="NSColor" key="IBUINormalTitleShadowColor">
+									<int key="NSColorSpace">3</int>
+									<bytes key="NSWhite">MC41AA</bytes>
+								</object>
+								<object class="IBUIFontDescription" key="IBUIFontDescription">
+									<int key="type">2</int>
+									<double key="pointSize">15</double>
+								</object>
+								<object class="NSFont" key="IBUIFont">
+									<string key="NSName">Helvetica-Bold</string>
+									<double key="NSSize">15</double>
+									<int key="NSfFlags">16</int>
+								</object>
+							</object>
+						</array>
+						<string key="NSFrameSize">{320, 504}</string>
+						<reference key="NSSuperview" ref="191373211"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="5460194"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<bool key="IBUIMultipleTouchEnabled">YES</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+					</object>
+				</array>
+				<string key="NSFrame">{{0, 64}, {320, 504}}</string>
+				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="111704902"/>
+				<object class="NSColor" key="IBUIBackgroundColor">
+					<int key="NSColorSpace">3</int>
+					<bytes key="NSWhite">MQA</bytes>
+					<object class="NSColorSpace" key="NSCustomColorSpace">
+						<int key="NSID">2</int>
+					</object>
+				</object>
+				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
+				<object class="IBUISimulatedNavigationBarMetrics" key="IBUISimulatedTopBarMetrics">
+					<bool key="IBUIPrompted">NO</bool>
+				</object>
+				<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
+					<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
+					<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<array key="dict.sortedKeys">
+							<integer value="1"/>
+							<integer value="3"/>
+						</array>
+						<array key="dict.values">
+							<string>{320, 568}</string>
+							<string>{568, 320}</string>
+						</array>
+					</object>
+					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
+					<string key="IBUIDisplayName">Retina 4 Full Screen</string>
+					<int key="IBUIType">2</int>
+				</object>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+		</array>
+		<object class="IBObjectContainer" key="IBDocument.Objects">
+			<array class="NSMutableArray" key="connectionRecords">
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">view</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="191373211"/>
+					</object>
+					<int key="connectionID">3</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">scrollView</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="111704902"/>
+					</object>
+					<int key="connectionID">64</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">scrollViewButton</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="5460194"/>
+					</object>
+					<int key="connectionID">65</int>
+				</object>
+			</array>
+			<object class="IBMutableOrderedSet" key="objectRecords">
+				<array key="orderedObjects">
+					<object class="IBObjectRecord">
+						<int key="objectID">0</int>
+						<array key="object" id="0"/>
+						<reference key="children" ref="1000"/>
+						<nil key="parent"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1</int>
+						<reference key="object" ref="191373211"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="111704902"/>
+						</array>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-1</int>
+						<reference key="object" ref="372490531"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">File's Owner</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-2</int>
+						<reference key="object" ref="975951072"/>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">4</int>
+						<reference key="object" ref="111704902"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="5460194"/>
+						</array>
+						<reference key="parent" ref="191373211"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">61</int>
+						<reference key="object" ref="5460194"/>
+						<reference key="parent" ref="111704902"/>
+					</object>
+				</array>
+			</object>
+			<dictionary class="NSMutableDictionary" key="flattenedProperties">
+				<string key="-1.CustomClassName">SLElementStateTestViewController</string>
+				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="-2.CustomClassName">UIResponder</string>
+				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="61.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			</dictionary>
+			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
+			<nil key="activeLocalization"/>
+			<dictionary class="NSMutableDictionary" key="localizations"/>
+			<nil key="sourceID"/>
+			<int key="maxID">65</int>
+		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<object class="IBPartialClassDescription">
+					<string key="className">SLElementStateTestViewController</string>
+					<string key="superclassName">SLTestCaseViewController</string>
+					<dictionary class="NSMutableDictionary" key="outlets">
+						<string key="button">UIButton</string>
+						<string key="coveringView">UIView</string>
+						<string key="scrollView">UIScrollView</string>
+						<string key="scrollViewButton">UIButton</string>
+					</dictionary>
+					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<object class="IBToOneOutletInfo" key="button">
+							<string key="name">button</string>
+							<string key="candidateClassName">UIButton</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="coveringView">
+							<string key="name">coveringView</string>
+							<string key="candidateClassName">UIView</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="scrollView">
+							<string key="name">scrollView</string>
+							<string key="candidateClassName">UIScrollView</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="scrollViewButton">
+							<string key="name">scrollViewButton</string>
+							<string key="candidateClassName">UIButton</string>
+						</object>
+					</dictionary>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/SLElementStateTestViewController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">SLTestCaseViewController</string>
+					<string key="superclassName">UIViewController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/SLTestCaseViewController.h</string>
+					</object>
+				</object>
+			</array>
+		</object>
+		<int key="IBDocument.localizationMode">0</int>
+		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
+		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
+		<int key="IBDocument.defaultPropertyAccessControl">3</int>
+		<string key="IBCocoaTouchPluginVersion">2083</string>
+	</data>
+</archive>

--- a/Integration Tests/Tests/SLElementStateTestViewController.m
+++ b/Integration Tests/Tests/SLElementStateTestViewController.m
@@ -30,6 +30,9 @@
 @property (weak, nonatomic) IBOutlet UIButton *button;
 @property (weak, nonatomic) IBOutlet UIView *coveringView;
 
+@property (weak, nonatomic) IBOutlet UIScrollView *scrollView;
+@property (weak, nonatomic) IBOutlet UIButton *scrollViewButton;
+
 @end
 
 
@@ -45,6 +48,9 @@
                testCase == @selector(testElementIsTappableIfItHasANonNullHitpoint) ||
                testCase == @selector(testCanRetrieveLabelEvenIfNotTappable)) {
         nibName = @"SLElementStateTestCompletelyCovered";
+    } else if (testCase == @selector(testScrollViewsAreNotTappableOnIPad5_x) ||
+               testCase == @selector(testScrollViewChildElementsAreTappableEvenOnIPad5_x)) {
+        nibName = @"SLElementStateTestScrollViewCases";
     }
     return nibName;
 }
@@ -89,6 +95,12 @@
 
     _testView.isAccessibilityElement = YES;
     _testView.accessibilityLabel = @"Test Element";
+
+    // we can't make the scroll view accessible in `testScrollViewsAreNotTappableOnIPad5_x`
+    // because that will prevent its child element from appearing in the accessibility hierarchy
+    if (self.testCase == @selector(testScrollViewsAreNotTappableOnIPad5_x)) {
+        self.scrollView.accessibilityIdentifier = @"scroll view";
+    }
 }
 
 - (instancetype)initWithTestCaseWithSelector:(SEL)testCase {

--- a/Integration Tests/Tests/SLElementTapTest.m
+++ b/Integration Tests/Tests/SLElementTapTest.m
@@ -58,6 +58,34 @@
     SLAssertTrue(SLAskApp(tapPoint) != nil, @"Tap should have been recognized.");
 }
 
+- (void)testCannotTapScrollViewsOnIPad5_x {
+    // this test should succeed given an iPhone running iOS 5.1,
+    // and an iPad running iOS 6.1
+    BOOL canTapScrollView = !((kCFCoreFoundationVersionNumber <= kCFCoreFoundationVersionNumber_iOS_5_1) &&
+                              ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad));
+    SLElement *scrollView = [SLElement elementWithAccessibilityIdentifier:@"scroll view"];
+    if (canTapScrollView) {
+        SLAssertNoThrow([UIAElement(scrollView) tap], @"Should have been able to tap scroll view.");
+        SLAssertTrue(SLAskApp(tapPoint) != nil, @"Scroll view should have been tapped.");
+    } else {
+        // If we had disallowed the tap on the basis of UIAutomation saying that
+        // the scroll view was not tappable, we would have thrown an SLElementNotTappableException.
+        SLAssertThrowsNamed([UIAElement(scrollView) tap],
+                            SLTerminalJavaScriptException,
+                            @"Should have allowed tap, but not have been able to tap element.");
+        // sanity check
+        SLAssertTrue(SLAskApp(tapPoint) == nil, @"Scroll view should not have been tapped.");
+    }
+}
+
+- (void)testCanTapChildElementsOfScrollViewsEvenOnIPad5_x {
+    SLButton *scrollViewButton = [SLButton elementWithAccessibilityLabel:@"Button"];
+    SLAssertNoThrow([UIAElement(scrollViewButton) tap],
+                    @"Should have been able to tap scroll view child element regardless of platform.");
+    // sanity check
+    SLAssertTrue(SLAskAppYesNo(scrollViewButtonWasTapped), @"Scroll view button should have been tapped.");
+}
+
 - (void)testTapOccursAtHitpoint {
     [UIAElement(_testElement) tap];
     CGPoint tapPoint = [SLAskApp(tapPoint) CGPointValue];

--- a/Integration Tests/Tests/SLElementTapTestScrollViewCases.xib
+++ b/Integration Tests/Tests/SLElementTapTestScrollViewCases.xib
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
+	<data>
+		<int key="IBDocument.SystemTarget">1552</int>
+		<string key="IBDocument.SystemVersion">12E55</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.39</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			<string key="NS.object.0">2083</string>
+		</object>
+		<array key="IBDocument.IntegratedClassDependencies">
+			<string>IBProxyObject</string>
+			<string>IBUIButton</string>
+			<string>IBUIScrollView</string>
+			<string>IBUIView</string>
+		</array>
+		<array key="IBDocument.PluginDependencies">
+			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+		</array>
+		<object class="NSMutableDictionary" key="IBDocument.Metadata">
+			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
+			<integer value="1" key="NS.object.0"/>
+		</object>
+		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
+			<object class="IBProxyObject" id="372490531">
+				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBProxyObject" id="975951072">
+				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBUIView" id="191373211">
+				<reference key="NSNextResponder"/>
+				<int key="NSvFlags">274</int>
+				<array class="NSMutableArray" key="NSSubviews">
+					<object class="IBUIScrollView" id="111704902">
+						<reference key="NSNextResponder" ref="191373211"/>
+						<int key="NSvFlags">274</int>
+						<array class="NSMutableArray" key="NSSubviews">
+							<object class="IBUIButton" id="5460194">
+								<reference key="NSNextResponder" ref="111704902"/>
+								<int key="NSvFlags">292</int>
+								<string key="NSFrame">{{20, 20}, {73, 44}}</string>
+								<reference key="NSSuperview" ref="111704902"/>
+								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView"/>
+								<string key="NSReuseIdentifierKey">_NS:9</string>
+								<bool key="IBUIOpaque">NO</bool>
+								<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+								<int key="IBUIContentHorizontalAlignment">0</int>
+								<int key="IBUIContentVerticalAlignment">0</int>
+								<int key="IBUIButtonType">1</int>
+								<string key="IBUINormalTitle">Button</string>
+								<object class="NSColor" key="IBUIHighlightedTitleColor">
+									<int key="NSColorSpace">3</int>
+									<bytes key="NSWhite">MQA</bytes>
+								</object>
+								<object class="NSColor" key="IBUINormalTitleColor">
+									<int key="NSColorSpace">1</int>
+									<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
+								</object>
+								<object class="NSColor" key="IBUINormalTitleShadowColor">
+									<int key="NSColorSpace">3</int>
+									<bytes key="NSWhite">MC41AA</bytes>
+								</object>
+								<object class="IBUIFontDescription" key="IBUIFontDescription">
+									<int key="type">2</int>
+									<double key="pointSize">15</double>
+								</object>
+								<object class="NSFont" key="IBUIFont">
+									<string key="NSName">Helvetica-Bold</string>
+									<double key="NSSize">15</double>
+									<int key="NSfFlags">16</int>
+								</object>
+							</object>
+						</array>
+						<string key="NSFrameSize">{320, 504}</string>
+						<reference key="NSSuperview" ref="191373211"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="5460194"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<bool key="IBUIMultipleTouchEnabled">YES</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+					</object>
+				</array>
+				<string key="NSFrame">{{0, 64}, {320, 504}}</string>
+				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="111704902"/>
+				<object class="NSColor" key="IBUIBackgroundColor">
+					<int key="NSColorSpace">3</int>
+					<bytes key="NSWhite">MQA</bytes>
+					<object class="NSColorSpace" key="NSCustomColorSpace">
+						<int key="NSID">2</int>
+					</object>
+				</object>
+				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
+				<object class="IBUISimulatedNavigationBarMetrics" key="IBUISimulatedTopBarMetrics">
+					<bool key="IBUIPrompted">NO</bool>
+				</object>
+				<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
+					<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
+					<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<array key="dict.sortedKeys">
+							<integer value="1"/>
+							<integer value="3"/>
+						</array>
+						<array key="dict.values">
+							<string>{320, 568}</string>
+							<string>{568, 320}</string>
+						</array>
+					</object>
+					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
+					<string key="IBUIDisplayName">Retina 4 Full Screen</string>
+					<int key="IBUIType">2</int>
+				</object>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+		</array>
+		<object class="IBObjectContainer" key="IBDocument.Objects">
+			<array class="NSMutableArray" key="connectionRecords">
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">view</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="191373211"/>
+					</object>
+					<int key="connectionID">3</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">scrollView</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="111704902"/>
+					</object>
+					<int key="connectionID">62</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">scrollViewButton</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="5460194"/>
+					</object>
+					<int key="connectionID">63</int>
+				</object>
+			</array>
+			<object class="IBMutableOrderedSet" key="objectRecords">
+				<array key="orderedObjects">
+					<object class="IBObjectRecord">
+						<int key="objectID">0</int>
+						<array key="object" id="0"/>
+						<reference key="children" ref="1000"/>
+						<nil key="parent"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1</int>
+						<reference key="object" ref="191373211"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="111704902"/>
+						</array>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-1</int>
+						<reference key="object" ref="372490531"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">File's Owner</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-2</int>
+						<reference key="object" ref="975951072"/>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">4</int>
+						<reference key="object" ref="111704902"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="5460194"/>
+						</array>
+						<reference key="parent" ref="191373211"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">61</int>
+						<reference key="object" ref="5460194"/>
+						<reference key="parent" ref="111704902"/>
+					</object>
+				</array>
+			</object>
+			<dictionary class="NSMutableDictionary" key="flattenedProperties">
+				<string key="-1.CustomClassName">SLElementTapTestViewController</string>
+				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="-2.CustomClassName">UIResponder</string>
+				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="61.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			</dictionary>
+			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
+			<nil key="activeLocalization"/>
+			<dictionary class="NSMutableDictionary" key="localizations"/>
+			<nil key="sourceID"/>
+			<int key="maxID">63</int>
+		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<object class="IBPartialClassDescription">
+					<string key="className">SLElementTapTestViewController</string>
+					<string key="superclassName">SLTestCaseViewController</string>
+					<dictionary class="NSMutableDictionary" key="outlets">
+						<string key="scrollView">UIScrollView</string>
+						<string key="scrollViewButton">UIButton</string>
+					</dictionary>
+					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<object class="IBToOneOutletInfo" key="scrollView">
+							<string key="name">scrollView</string>
+							<string key="candidateClassName">UIScrollView</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="scrollViewButton">
+							<string key="name">scrollViewButton</string>
+							<string key="candidateClassName">UIButton</string>
+						</object>
+					</dictionary>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/SLElementTapTestViewController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">SLTestCaseViewController</string>
+					<string key="superclassName">UIViewController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/SLTestCaseViewController.h</string>
+					</object>
+				</object>
+			</array>
+		</object>
+		<int key="IBDocument.localizationMode">0</int>
+		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
+		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
+		<int key="IBDocument.defaultPropertyAccessControl">3</int>
+		<string key="IBCocoaTouchPluginVersion">2083</string>
+	</data>
+</archive>

--- a/Integration Tests/Tests/SLElementVisibilityTest.m
+++ b/Integration Tests/Tests/SLElementVisibilityTest.m
@@ -226,15 +226,26 @@
 }
 
 - (void)testAccessibilityElementIsNotVisibleIfContainerIsHiddenEvenInTableViewCell {
-    // for some reason, UIAElement.isVisible always returns true
+    // on iOS 6, UIAElement.isVisible always returns true
     // for elements in table view cells, even if those elements' containers are hidden
-    SLAssertTrue([_testElement uiaIsVisible], @"UIAutomation should say that the element is not visible, but it doesn't.");
+    if (kCFCoreFoundationVersionNumber > kCFCoreFoundationVersionNumber_iOS_5_1) {
+        SLAssertTrue([_testElement uiaIsVisible], @"UIAutomation should say that the element is not visible, but it doesn't.");
+    } else {
+        SLAssertFalse([_testElement uiaIsVisible], @"UIAutomation should say that the element is not visible.");
+    }
     SLAssertFalse([_testElement isVisible], @"Subliminal should say that the element is not visible.");
 
     // the test view is the container of the test element
     SLAskApp(showTestView);
 
-    SLAssertTrue([_testElement uiaIsVisible], @"UIAutomation should say that the element is visible.");
+    // on iOS 5, table view cells appear to cache their accessibility state,
+    // so, the test view having started out hidden, UIAElement.isVisible will return false
+    // even though its container is now visible
+    if (kCFCoreFoundationVersionNumber > kCFCoreFoundationVersionNumber_iOS_5_1) {
+        SLAssertTrue([_testElement uiaIsVisible], @"UIAutomation should say that the element is visible.");
+    } else {
+        SLAssertFalse([_testElement uiaIsVisible], @"UIAutomation should say that the element is visible, but it doesn't.");
+    }
     SLAssertTrue([_testElement isVisible], @"Subliminal should say that the element is visible.");
 }
 

--- a/Integration Tests/Tests/SLElementVisibilityTestViewController.m
+++ b/Integration Tests/Tests/SLElementVisibilityTestViewController.m
@@ -186,6 +186,8 @@
 @end
 
 @implementation SLElementVisibilityTestViewController {
+    NSString *_testTableViewCellIdentifier;
+
     UIWebView *_webView;
     BOOL _webViewDidFinishLoad;
 }
@@ -253,7 +255,6 @@
     [[SLTestController sharedTestController] deregisterTarget:self];
 }
 
-static NSString *TestCellIdentifier = nil;
 - (void)loadViewForTestCase:(SEL)testCase {
     if (testCase == @selector(testViewIsNotVisibleIfItIsHiddenEvenInTableViewCell) ||
         testCase == @selector(testAccessibilityElementIsNotVisibleIfContainerIsHiddenEvenInTableViewCell)) {
@@ -264,11 +265,7 @@ static NSString *TestCellIdentifier = nil;
         tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         tableView.delegate = self;
         tableView.dataSource = self;
-        Class containerViewCellClass = [SLElementVisibilityTestCell class];
-        TestCellIdentifier = [NSString stringWithFormat:@"%@_%@",
-                              NSStringFromClass(containerViewCellClass), NSStringFromSelector(testCase)];
-        [tableView registerClass:containerViewCellClass forCellReuseIdentifier:TestCellIdentifier];
-        tableView.rowHeight = [containerViewCellClass rowHeight];
+        tableView.rowHeight = [SLElementVisibilityTestCell rowHeight];
         [view addSubview:tableView];
 
         self.view = view;
@@ -329,7 +326,15 @@ static NSString *TestCellIdentifier = nil;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    SLElementVisibilityTestCell *cell = (SLElementVisibilityTestCell *) [tableView dequeueReusableCellWithIdentifier:TestCellIdentifier forIndexPath:indexPath];
+    if (!_testTableViewCellIdentifier) {
+        _testTableViewCellIdentifier = [NSString stringWithFormat:@"%@_%@",
+                                        NSStringFromClass([SLElementVisibilityTestCell class]), NSStringFromSelector(self.testCase)];
+    }
+
+    SLElementVisibilityTestCell *cell = (SLElementVisibilityTestCell *)[tableView dequeueReusableCellWithIdentifier:_testTableViewCellIdentifier];
+    if (!cell) {
+        cell = [[SLElementVisibilityTestCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:_testTableViewCellIdentifier];
+    }
 
     if (self.testCase == @selector(testViewIsNotVisibleIfItIsHiddenEvenInTableViewCell)) {
         cell.testView.isAccessibilityElement = YES;

--- a/Integration Tests/Tests/SLStaticElementTestScrollView.xib
+++ b/Integration Tests/Tests/SLStaticElementTestScrollView.xib
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
+	<data>
+		<int key="IBDocument.SystemTarget">1552</int>
+		<string key="IBDocument.SystemVersion">12E55</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.39</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			<string key="NS.object.0">2083</string>
+		</object>
+		<array key="IBDocument.IntegratedClassDependencies">
+			<string>IBProxyObject</string>
+			<string>IBUIScrollView</string>
+			<string>IBUIView</string>
+		</array>
+		<array key="IBDocument.PluginDependencies">
+			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+		</array>
+		<object class="NSMutableDictionary" key="IBDocument.Metadata">
+			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
+			<integer value="1" key="NS.object.0"/>
+		</object>
+		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
+			<object class="IBProxyObject" id="372490531">
+				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBProxyObject" id="975951072">
+				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBUIView" id="191373211">
+				<reference key="NSNextResponder"/>
+				<int key="NSvFlags">274</int>
+				<array class="NSMutableArray" key="NSSubviews">
+					<object class="IBUIScrollView" id="111704902">
+						<reference key="NSNextResponder" ref="191373211"/>
+						<int key="NSvFlags">274</int>
+						<array class="NSMutableArray" key="NSSubviews"/>
+						<string key="NSFrameSize">{320, 504}</string>
+						<reference key="NSSuperview" ref="191373211"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<bool key="IBUIMultipleTouchEnabled">YES</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+					</object>
+				</array>
+				<string key="NSFrame">{{0, 64}, {320, 504}}</string>
+				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="111704902"/>
+				<object class="NSColor" key="IBUIBackgroundColor">
+					<int key="NSColorSpace">3</int>
+					<bytes key="NSWhite">MQA</bytes>
+					<object class="NSColorSpace" key="NSCustomColorSpace">
+						<int key="NSID">2</int>
+					</object>
+				</object>
+				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
+				<object class="IBUISimulatedNavigationBarMetrics" key="IBUISimulatedTopBarMetrics">
+					<bool key="IBUIPrompted">NO</bool>
+				</object>
+				<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
+					<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
+					<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<array key="dict.sortedKeys">
+							<integer value="1"/>
+							<integer value="3"/>
+						</array>
+						<array key="dict.values">
+							<string>{320, 568}</string>
+							<string>{568, 320}</string>
+						</array>
+					</object>
+					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
+					<string key="IBUIDisplayName">Retina 4 Full Screen</string>
+					<int key="IBUIType">2</int>
+				</object>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+		</array>
+		<object class="IBObjectContainer" key="IBDocument.Objects">
+			<array class="NSMutableArray" key="connectionRecords">
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">view</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="191373211"/>
+					</object>
+					<int key="connectionID">3</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">scrollView</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="111704902"/>
+					</object>
+					<int key="connectionID">66</int>
+				</object>
+			</array>
+			<object class="IBMutableOrderedSet" key="objectRecords">
+				<array key="orderedObjects">
+					<object class="IBObjectRecord">
+						<int key="objectID">0</int>
+						<array key="object" id="0"/>
+						<reference key="children" ref="1000"/>
+						<nil key="parent"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1</int>
+						<reference key="object" ref="191373211"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="111704902"/>
+						</array>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-1</int>
+						<reference key="object" ref="372490531"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">File's Owner</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-2</int>
+						<reference key="object" ref="975951072"/>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">4</int>
+						<reference key="object" ref="111704902"/>
+						<array class="NSMutableArray" key="children"/>
+						<reference key="parent" ref="191373211"/>
+					</object>
+				</array>
+			</object>
+			<dictionary class="NSMutableDictionary" key="flattenedProperties">
+				<string key="-1.CustomClassName">SLStaticElementTestViewController</string>
+				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="-2.CustomClassName">UIResponder</string>
+				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			</dictionary>
+			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
+			<nil key="activeLocalization"/>
+			<dictionary class="NSMutableDictionary" key="localizations"/>
+			<nil key="sourceID"/>
+			<int key="maxID">66</int>
+		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<object class="IBPartialClassDescription">
+					<string key="className">SLStaticElementTestViewController</string>
+					<string key="superclassName">SLTestCaseViewController</string>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">scrollView</string>
+						<string key="NS.object.0">UIScrollView</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">scrollView</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0">
+							<string key="name">scrollView</string>
+							<string key="candidateClassName">UIScrollView</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/SLStaticElementTestViewController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">SLTestCaseViewController</string>
+					<string key="superclassName">UIViewController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/SLTestCaseViewController.h</string>
+					</object>
+				</object>
+			</array>
+		</object>
+		<int key="IBDocument.localizationMode">0</int>
+		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
+		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
+		<int key="IBDocument.defaultPropertyAccessControl">3</int>
+		<string key="IBCocoaTouchPluginVersion">2083</string>
+	</data>
+</archive>

--- a/Integration Tests/Tests/SLStaticElementTestViewController.m
+++ b/Integration Tests/Tests/SLStaticElementTestViewController.m
@@ -25,12 +25,20 @@
 #import <Subliminal/SLTestController+AppHooks.h>
 
 @interface SLStaticElementTestViewController : SLTestCaseViewController
-
+@property (weak, nonatomic) IBOutlet UIScrollView *scrollView;
 @end
 
 @implementation SLStaticElementTestViewController {
     UIButton *_button;
     BOOL _buttonWasTapped;
+}
+
++ (NSString *)nibNameForTestCase:(SEL)testCase {
+    NSString *nibName = nil;
+    if (testCase == @selector(testStaticElementsDoNotWaitUntilTappableIfIsScrollViewIsYESAndIsIPad5_x)) {
+        nibName = @"SLStaticElementTestScrollView";
+    }
+    return nibName;
 }
 
 - (void)loadViewForTestCase:(SEL)testCase {
@@ -48,6 +56,10 @@
     _button.accessibilityIdentifier = @"SLTestStaticElement";
     _button.accessibilityValue = @"elementValue";
     [_button addTarget:self action:@selector(buttonTapped:) forControlEvents:UIControlEventTouchUpInside];
+
+    self.scrollView.accessibilityIdentifier = @"scroll view";
+    self.scrollView.backgroundColor = [UIColor blueColor];
+    self.scrollView.hidden = YES;
 }
 
 - (void)viewWillLayoutSubviews {
@@ -66,6 +78,8 @@
         [[SLTestController sharedTestController] registerTarget:self forAction:@selector(showButtonAfterInterval:)];
         [[SLTestController sharedTestController] registerTarget:self forAction:@selector(hideButton)];
         [[SLTestController sharedTestController] registerTarget:self forAction:@selector(buttonWasTapped)];
+        [[SLTestController sharedTestController] registerTarget:self forAction:@selector(hideScrollView)];
+        [[SLTestController sharedTestController] registerTarget:self forAction:@selector(showScrollViewAfterInterval:)];
     }
     return self;
 }
@@ -107,6 +121,23 @@
 
 - (void)buttonTapped:(id)sender {
     _buttonWasTapped = YES;
+}
+
+- (void)hideScrollView {
+    self.scrollView.hidden = YES;
+}
+
+- (void)showScrollView {
+    self.scrollView.hidden = NO;
+}
+
+- (void)showScrollViewAfterInterval:(NSNumber *)intervalNumber {
+    NSTimeInterval delay = [intervalNumber doubleValue];
+    if (!delay) {
+        [self showScrollView];
+    } else {
+        [self performSelector:@selector(showScrollView) withObject:nil afterDelay:delay];
+    }
 }
 
 @end

--- a/Integration Tests/Tests/SLTableViewChildElementMatchingTestViewController.xib
+++ b/Integration Tests/Tests/SLTableViewChildElementMatchingTestViewController.xib
@@ -11,7 +11,6 @@
 			<string key="NS.object.0">2083</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBNSLayoutConstraint</string>
 			<string>IBProxyObject</string>
 			<string>IBUITableView</string>
 			<string>IBUIView</string>
@@ -137,70 +136,6 @@
 						<int key="objectID">1</int>
 						<reference key="object" ref="191373211"/>
 						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="484077719">
-								<reference key="firstItem" ref="754939039"/>
-								<int key="firstAttribute">4</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">4</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="470904977">
-								<reference key="firstItem" ref="754939039"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">3</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="416805649">
-								<reference key="firstItem" ref="754939039"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">5</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="664179831">
-								<reference key="firstItem" ref="754939039"/>
-								<int key="firstAttribute">6</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
 							<reference ref="754939039"/>
 						</array>
 						<reference key="parent" ref="0"/>
@@ -222,26 +157,6 @@
 						<array class="NSMutableArray" key="children"/>
 						<reference key="parent" ref="191373211"/>
 					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">29</int>
-						<reference key="object" ref="664179831"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">30</int>
-						<reference key="object" ref="416805649"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">42</int>
-						<reference key="object" ref="470904977"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">46</int>
-						<reference key="object" ref="484077719"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -250,18 +165,7 @@
 				<string key="-2.CustomClassName">UIResponder</string>
 				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<array key="1.IBViewMetadataConstraints">
-					<reference ref="664179831"/>
-					<reference ref="416805649"/>
-					<reference ref="470904977"/>
-					<reference ref="484077719"/>
-				</array>
-				<string key="29.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="3.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<boolean value="NO" key="3.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-				<string key="30.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="42.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="46.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 			</dictionary>
 			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
 			<nil key="activeLocalization"/>
@@ -272,22 +176,19 @@
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
 				<object class="IBPartialClassDescription">
-					<string key="className">NSLayoutConstraint</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/NSLayoutConstraint.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
 					<string key="className">SLElementMatchingTestViewController</string>
 					<string key="superclassName">SLTestCaseViewController</string>
 					<dictionary class="NSMutableDictionary" key="outlets">
+						<string key="barButton">UIButton</string>
 						<string key="fooButton">UIButton</string>
 						<string key="searchBar">UISearchBar</string>
 						<string key="tableView">UITableView</string>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<object class="IBToOneOutletInfo" key="barButton">
+							<string key="name">barButton</string>
+							<string key="candidateClassName">UIButton</string>
+						</object>
 						<object class="IBToOneOutletInfo" key="fooButton">
 							<string key="name">fooButton</string>
 							<string key="candidateClassName">UIButton</string>
@@ -320,7 +221,6 @@
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<bool key="IBDocument.UseAutolayout">YES</bool>
 		<string key="IBCocoaTouchPluginVersion">2083</string>
 	</data>
 </archive>

--- a/Integration Tests/Tests/SLTextFieldTestViewController.m
+++ b/Integration Tests/Tests/SLTextFieldTestViewController.m
@@ -116,11 +116,15 @@
 - (void)viewWillLayoutSubviews {
     [super viewWillLayoutSubviews];
 
-    _textField.center = self.view.center;
+    // move the textfield above the keyboard
+    static const CGFloat kTextFieldVerticalOffset = -40.0f;
+
+    CGPoint textFieldCenter = CGPointMake(self.view.center.x, self.view.center.y + kTextFieldVerticalOffset);
+    _textField.center = textFieldCenter;
     if (_textField) {
         _searchBar.center = CGPointMake(_textField.center.x, _textField.center.y - 50.0f);
     } else {
-        _searchBar.center = self.view.center;
+        _searchBar.center = textFieldCenter;
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -277,9 +277,7 @@ application and tests.
 Requirements
 ------------
 
-Subliminal currently requires Xcode 4.6.x and iOS 6.x. 
-
-iOS 5 support is [in review](https://github.com/inkling/Subliminal/pull/11).
+Subliminal currently supports Xcode 4.6.x and iOS 5.0 through 6.1. 
 
 We are closely monitoring the development of Xcode 5 and the iOS 7 SDK. It is 
 very likely that we will announce at least partial support before 7 goes Gold 
@@ -321,9 +319,11 @@ export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
 # Run the tests in the non-retina iPhone Simulator
 DEVICE="iPhone"
 
-# A bug in Instruments (http://openradar.appspot.com/radar?id=1544403) 
-# requires that the script be invoked with the current user's login password in order 
-# to run fully un-attended
+# Run the tests on iOS 6.1
+VERSION=6.1
+
+# Allow `subliminal-test` to work around bugs in Apple's `instruments` tool 
+# while running un-attended. See the FAQ for more information.
 PASSWORD="password1234"
 
 OUTPUT_DIR=reports
@@ -334,6 +334,7 @@ mkdir -p "$OUTPUT_DIR"
 "$PROJECT_DIR/Integration Tests/Subliminal/Supporting Files/CI/subliminal-test" \
 	-project "$YOUR_PROJECT" \
 	-sim_device "$DEVICE" \
+	-sim_version "$VERSION" \
 	-login_password "$PASSWORD" \
 	-output "$OUTPUT_DIR"
 ```
@@ -491,6 +492,35 @@ FAQ
 		to break immediately after launch, you may find it useful to give yourself 
 		time to attach the debugger by setting `-[SLTestController shouldWaitToStartTesting]` 
 		to `YES`.
+
+### Continuous Integration
+
+*	Why does the `subliminal-test` script require my login password?
+
+	`subliminal-test` can work around several bugs in Apple's `instruments` tool, 
+	but only with superuser privileges. Providing your password lets the script 
+	run un-attended. The password is used:
+
+	1.	To authorize `instruments` to take control of your application if it asks 
+		for such permission when launched: http://openradar.appspot.com/radar?id=1544403.
+	2.	To temporarily modify the Xcode folder to force `instruments` to use the 
+		specified SDK to run the tests, whereas it otherwise would only use the 
+		latest SDK installed: http://openradar.appspot.com/radar?id=3107401.
+
+	`subliminal-test` cannot itself be run with superuser privileges because 
+	`instruments` only works properly if it is run as the user.
+
+	If a developer will be attending the tests as they execute (for instance on 
+	their local machine rather than on the build server), and so can enter their 
+	password as required, they may execute `subliminal-test` with the `--live` option.
+
+	We would gladly welcome alternate workarounds for the issues above. In some 
+	environments, [modifying `/etc/authorization`](http://stackoverflow.com/a/11416025/495611) 
+	will suffice to authorize `instruments`. And, if developers only need to test 
+	on the latest SDK, they can rely on `instruments` using that SDK by default, 
+	and avoid specifying an SDK version--though that behavior may change with the 
+	Xcode 5 developer tools: see the note at the bottom of the bug report 
+	[here](http://openradar.appspot.com/radar?id=3107401).
 
 Known Issues
 ------------

--- a/README.md
+++ b/README.md
@@ -492,6 +492,24 @@ FAQ
 		time to attach the debugger by setting `-[SLTestController shouldWaitToStartTesting]` 
 		to `YES`.
 
+Known Issues
+------------
+
+> This section is reserved for issues that Subliminal cannot resolve, due to 
+limitations of Apple's frameworks or bugs therein. Other issues are tracked 
+[here](https://github.com/inkling/Subliminal/issues).
+
+* 	UIAutomation reports that scroll views are never tappable in applications 
+	running on iPad simulators or devices running iOS 5.x. On such platforms, 
+	Subliminal attempts to interact with scroll views despite UIAutomation reporting 
+	that they are not tappable--whereas on other platforms (not iPad, or not running 
+	iOS 5.x), Subliminal requires that elements be tappable before interaction 
+	can proceed.
+
+	Testing reveals that tapping scroll views on an iPad simulator or device 
+	running iOS 5.x will fail, but dragging will succeed. Also, UIAutomation 
+	correctly reports scroll view child elements as tappable regardless of platform.
+
 Contributing
 ------------
 

--- a/Rakefile
+++ b/Rakefile
@@ -368,11 +368,28 @@ namespace :test do
   task :unit => :prepare do    
     puts "- Running unit tests...\n\n"
 
+    base_command = 'xctool -project Subliminal.xcodeproj/ -scheme "Subliminal Unit Tests" -sdk iphonesimulator'
+
     # Use system so we see the tests' output
-    if system('xctool -project Subliminal.xcodeproj/ -scheme "Subliminal Unit Tests" clean test')
-      puts "Unit tests passed.\n\n"
-    else      
-      fail "Unit tests failed."
+    fail "Unit tests failed to build." unless system("#{base_command} clean build-tests")
+
+    tests_succeeded = true
+    test_on_sdk = lambda { |sdk|
+      puts "-- Running unit tests on iOS #{sdk}..."
+      if system("#{base_command} run-tests -test-sdk iphonesimulator#{sdk}")
+        puts "Unit tests succeeded on iOS #{sdk}.\n\n"
+      else
+        puts "Unit tests failed on iOS #{sdk}.\n\n"
+        tests_succeeded = false
+      end
+    }
+    test_on_sdk.call("5.1")
+    test_on_sdk.call("6.1")
+
+    if tests_succeeded
+      puts "\nUnit tests passed.\n\n"
+    else
+      fail "\nUnit tests failed.\n\n"
     end
   end
 

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityDescription.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityDescription.m
@@ -56,7 +56,10 @@
     NSMutableArray *traitNames = [NSMutableArray array];
     if (traits & UIAccessibilityTraitButton)                  [traitNames addObject:@"Button"];
     if (traits & UIAccessibilityTraitLink)                    [traitNames addObject:@"Link"];
-    if (traits & UIAccessibilityTraitHeader)                  [traitNames addObject:@"Header"];
+    // UIAccessibilityTraitHeader is only available starting in iOS 6
+    if (kCFCoreFoundationVersionNumber > kCFCoreFoundationVersionNumber_iOS_5_1) {
+        if (traits & UIAccessibilityTraitHeader)                  [traitNames addObject:@"Header"];
+    }
     if (traits & UIAccessibilityTraitSearchField)             [traitNames addObject:@"Search Field"];
     if (traits & UIAccessibilityTraitImage)                   [traitNames addObject:@"Image"];
     if (traits & UIAccessibilityTraitSelected)                [traitNames addObject:@"Selected"];

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLElement.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLElement.m
@@ -132,6 +132,34 @@ UIAccessibilityTraits SLUIAccessibilityTraitAny = 0;
     return [NSString stringWithFormat:@"<%@ description:\"%@\">", NSStringFromClass([self class]), _description];
 }
 
+- (BOOL)canDetermineTappabilityUsingAccessibilityPath:(SLAccessibilityPath *)path {
+    BOOL canDetermineTappability = YES;
+    if ((kCFCoreFoundationVersionNumber <= kCFCoreFoundationVersionNumber_iOS_5_1)
+        && ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)) {
+        __block BOOL matchingObjectIsScrollView = NO;
+        [path examineLastPathComponent:^(NSObject *lastPathComponent) {
+            matchingObjectIsScrollView = [lastPathComponent isKindOfClass:[UIScrollView class]];
+        }];
+        canDetermineTappability = !matchingObjectIsScrollView;
+    }
+    return canDetermineTappability;
+}
+
+- (BOOL)canDetermineTappability {
+    BOOL canDetermineTappability = YES;
+    // incur the cost of a path lookup only if necessary
+    if ((kCFCoreFoundationVersionNumber <= kCFCoreFoundationVersionNumber_iOS_5_1)
+        && ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)) {
+        // like `-isTappable`, evaluate the current state, no waiting to resolve the element
+        SLAccessibilityPath *accessibilityPath = [self accessibilityPathWithTimeout:0.0];
+        if (!accessibilityPath) {
+            [NSException raise:SLUIAElementInvalidException format:@"Element '%@' does not exist.", self];
+        }
+        canDetermineTappability = [self canDetermineTappabilityUsingAccessibilityPath:accessibilityPath];
+    }
+    return canDetermineTappability;
+}
+
 - (SLAccessibilityPath *)accessibilityPathWithTimeout:(NSTimeInterval)timeout {
     __block SLAccessibilityPath *accessibilityPath = nil;
     NSDate *startDate = [NSDate date];
@@ -169,7 +197,9 @@ UIAccessibilityTraits SLUIAccessibilityTraitAny = 0;
         // catch and rethrow exceptions so that we can unbind the path
         @try {
             NSString *UIARepresentation = [boundPath UIARepresentation];
-            if (waitUntilTappable) {
+            // evaluate canDetermineTappability using the current path
+            // because we can't retrieve another while the element is bound
+            if (waitUntilTappable && [self canDetermineTappabilityUsingAccessibilityPath:accessibilityPath]) {
                 if (![[SLTerminal sharedTerminal] waitUntilFunctionWithNameIsTrue:[[self class]SLElementIsTappableFunctionName]
                                                             whenEvaluatedWithArgs:@[ UIARepresentation ]
                                                                        retryDelay:SLUIAElementWaitRetryDelay
@@ -177,7 +207,6 @@ UIAccessibilityTraits SLUIAccessibilityTraitAny = 0;
                     [NSException raise:SLUIAElementNotTappableException format:@"Element '%@' is not tappable.", self];
                 }
             }
-
             block(UIARepresentation);
         }
         @catch (NSException *exception) {

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLElement.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLElement.m
@@ -60,7 +60,10 @@ UIAccessibilityTraits SLUIAccessibilityTraitAny = 0;
         
         if (traits & UIAccessibilityTraitButton)                  [traitNames addObject:@"Button"];
         if (traits & UIAccessibilityTraitLink)                    [traitNames addObject:@"Link"];
-        if (traits & UIAccessibilityTraitHeader)                  [traitNames addObject:@"Header"];
+        // UIAccessibilityTraitHeader is only available starting in iOS 6
+        if (kCFCoreFoundationVersionNumber > kCFCoreFoundationVersionNumber_iOS_5_1) {
+            if (traits & UIAccessibilityTraitHeader)                  [traitNames addObject:@"Header"];
+        }
         if (traits & UIAccessibilityTraitSearchField)             [traitNames addObject:@"Search Field"];
         if (traits & UIAccessibilityTraitImage)                   [traitNames addObject:@"Image"];
         if (traits & UIAccessibilityTraitSelected)                [traitNames addObject:@"Selected"];

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLStaticElement.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLStaticElement.h
@@ -69,4 +69,20 @@
  */
 - (instancetype)initWithUIARepresentation:(NSString *)UIARepresentation;
 
+/**
+ Informs Subliminal that this element identifies an instance of `UIScrollView`.
+ 
+ Developers must set this to `YES` for an element used to represent a scroll view
+ in tests that will be run on an iPad 5.x simulator or device, due to 
+ [a bug in UIAutomation](-isTappable).
+ 
+ When this is set to `YES` and tests are running on an iPad simulator or device 
+ running iOS 5.x, Subliminal will not try to determine tappability when simulating 
+ user interaction with that scroll view, because UIAutomation will always say 
+ that the scroll view is not tappable.
+
+ Defaults to `NO`.
+ */
+@property (nonatomic) BOOL isScrollView;
+
 @end

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLStaticElement.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLStaticElement.m
@@ -41,6 +41,15 @@
     return [NSString stringWithFormat:@"<%@>", NSStringFromClass([self class])];
 }
 
+- (BOOL)canDetermineTappability {
+    BOOL canDetermineTappability = YES;
+    if ((kCFCoreFoundationVersionNumber <= kCFCoreFoundationVersionNumber_iOS_5_1)
+        && ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)) {
+        canDetermineTappability = !self.isScrollView;
+    }
+    return canDetermineTappability;
+}
+
 - (void)waitUntilTappable:(BOOL)waitUntilTappable
         thenPerformActionWithUIARepresentation:(void (^)(NSString *UIARepresentation))block
                                        timeout:(NSTimeInterval)timeout {
@@ -56,7 +65,7 @@
     NSTimeInterval resolutionDuration = resolutionEnd - resolutionStart;
     NSTimeInterval remainingTimeout = timeout - resolutionDuration;
     
-    if (waitUntilTappable) {
+    if (waitUntilTappable && [self canDetermineTappability]) {
         if (![[SLTerminal sharedTerminal] waitUntilFunctionWithNameIsTrue:[[self class] SLElementIsTappableFunctionName]
                                                     whenEvaluatedWithArgs:@[ _UIARepresentation ]
                                                                retryDelay:SLUIAElementWaitRetryDelay

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLUIAElement+Subclassing.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLUIAElement+Subclassing.h
@@ -60,9 +60,9 @@
  using `-[NSString slStringByEscapingForJavaScriptLiteral]`,
  if they are to be substituted into a JavaScript string literal.
 
- @param waitUntilTappable If `YES`, this method will wait for the remainder 
- of the default timeout after the element becomes valid for the element to 
- become tappable.
+ @param waitUntilTappable If `YES`, and `-canDetermineTappability` returns `YES`, 
+ this method will wait for the remainder of the default timeout, after the element
+ becomes valid, for the element to become tappable.
  @param action A format string (in the manner of `-[NSString stringWithFormat:]`) 
  representing a JavaScript function to be called on the corresponding `UIAElement`.
  @param ... (Optional) A comma-separated list of arguments to substitute into 
@@ -73,9 +73,9 @@
  @exception SLUIAElementInvalidException Raised if the element is not valid
  by the end of the default timeout.
 
- @exception SLUIAElementNotTappableException Raised if the element is not 
- tappable when whatever amount of time remains of the default timeout after 
- the element becomes valid elapses.
+ @exception SLUIAElementNotTappableException Raised if the element waits for
+ tappability and is not tappable when whatever amount of time remains of the 
+ default timeout, after the element becomes valid, elapses.
  */
 - (id)waitUntilTappable:(BOOL)waitUntilTappable
         thenSendMessage:(NSString *)action, ... NS_FORMAT_FUNCTION(2, 3);
@@ -100,13 +100,21 @@
  @warning If the expression to be evaluated by `block` involves user interaction,
  the caller must pass `YES` for `waitUntilTappable`.
 
- @param waitUntilTappable If `YES`, this method will wait for the remainder
- of `timeout` after the element becomes valid for the element to become tappable.
+ @param waitUntilTappable If `YES`, and `-canDetermineTappability` returns `YES`, 
+ this method will wait for the remainder of `timeout`, after the element becomes valid, 
+ for the element to become tappable.
  @param block A block which takes the UIAutomation representation of the specified 
  element as an argument and returns `void`.
  @param timeout The timeout for which this method should wait for the specified 
  element to become valid (and tappable, if `waitUntilTappable` is YES). Clients 
  should generally call this method with `+[SLUIAElement defaultTimeout]`.
+ 
+ @exception SLUIAElementInvalidException Raised if the element is not valid
+ by the end of `timeout`.
+
+ @exception SLUIAElementNotTappableException Raised if the element waits for 
+ tappability and is not tappable when whatever amount of time remains of `timeout`,
+ after the element becomes valid, elapses.
  */
 - (void)waitUntilTappable:(BOOL)waitUntilTappable
         thenPerformActionWithUIARepresentation:(void(^)(NSString *UIARepresentation))block
@@ -124,6 +132,24 @@
  `UIAElement` is tappable.
  */
 + (NSString *)SLElementIsTappableFunctionName;
+
+/**
+ Determines whether the specified element's response to `-isTappable` is valid.
+ 
+ This should return `YES` unless the specified element identifies an instance 
+ of `UIScrollView` and tests are running on an iPad simulator or device running 
+ iOS 5.x. On those platforms, UIAutomation reports that scroll views are always 
+ invisible, and thus not tappable.
+ 
+ If this method returns `NO`, tappability will not be enforced as a prerequisite 
+ for simulating user interaction. This will let Subliminal attempt interaction 
+ with scroll views despite UIAutomation's response. Testing reveals that certain 
+ forms of interaction, e.g. dragging, will yet succeed (barring factors like the 
+ scroll view actually being hidden or having user interaction disabled, etc.).
+ 
+ @exception SLUIAElementInvalidException Raised if the element is not valid.
+ */
+- (BOOL)canDetermineTappability;
 
 @end
 

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLUIAElement.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLUIAElement.h
@@ -171,19 +171,32 @@
  become tappable within that interval, the method will raise an 
  `SLUIAElementNotTappableException`.
  
+ This method returns, or raises an `SLUIAElementInvalidException`, immediately.
+ 
  Use of the `UIAElement` macro can help tests diagnose tappability failures.
  
  @warning [Visibility](-isVisible) correlates very closely with tappability, 
  but in some circumstances, an element may be tappable even if it is not visible, 
- and vice versa, due to bugs in `UIAutomation`. See the implementation for details.
+ and vice versa, due to bugs in UIAutomation. See the implementation for details.
  Tests should assert visibility separately if desired.
+ 
+ @bug UIAutomation reports that scroll views are never tappable in applications 
+ running on iPad simulators or devices running iOS 5.x. On such platforms, Subliminal 
+ attempts to interact with scroll views despite UIAutomation reporting that they 
+ are not tappable. Testing reveals that tapping scroll views on an iPad simulator 
+ or device running iOS 5.x will fail, but dragging will succeed (barring factors 
+ like the scroll view actually being hidden or having user interaction disabled, 
+ etc.).
+ 
+ UIAutomation correctly reports scroll view child elements as tappable 
+ regardless of platform.
 
  @return `YES` if it is possible to tap on or otherwise interact with the user
  interface element represented by the specified element, `NO` otherwise.
  
- @exception SLUIAElementInvalidException Raised if the element is not valid
- by the end of the [default timeout](+defaultTimeout).
-
+ @exception SLUIAElementInvalidException Raised if the element is not currently
+ valid.
+ 
  @see -isValid
  */
 - (BOOL)isTappable;
@@ -198,6 +211,14 @@
  
  The tap occurs at the element's [hitpoint](-hitpoint).
  
+ @bug This method will fail if the specified element identifies a scroll view
+ in an application running on an iPad simulator or device running iOS 5.x, due 
+ to a bug in UIAutomation (see -isTappable). An `SLTerminalJavaScriptException` 
+ will be raised in such a scenario.
+ 
+ UIAutomation is able to tap on scroll view child elements 
+ regardless of platform.
+
  @exception SLUIAElementInvalidException Raised if the element is not valid
  by the end of the [default timeout](+defaultTimeout).
  

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLUIAElement.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLUIAElement.m
@@ -141,6 +141,11 @@ static const void *const kDefaultTimeoutKey = &kDefaultTimeoutKey;
     return isTappable;
 }
 
+- (BOOL)canDetermineTappability {
+    // Concrete subclasses must determine whether instances identify scroll views.
+    return YES;
+}
+
 - (void)tap {
     [self waitUntilTappable:YES thenSendMessage:@"tap()"];
 }

--- a/Subliminal.xcodeproj/project.pbxproj
+++ b/Subliminal.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		F00800CF174C1C64001927AC /* SLPopover.m in Sources */ = {isa = PBXBuildFile; fileRef = F00800CD174C1C64001927AC /* SLPopover.m */; };
 		F00800E2174C2E0A001927AC /* SLPopoverTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F00800E0174C2E0A001927AC /* SLPopoverTest.m */; };
 		F00800E3174C2E0A001927AC /* SLPopoverTestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F00800E1174C2E0A001927AC /* SLPopoverTestViewController.m */; };
+		F00F3B5E1778E05100119580 /* SLElementTapTestScrollViewCases.xib in Resources */ = {isa = PBXBuildFile; fileRef = F00F3B5D1778E05100119580 /* SLElementTapTestScrollViewCases.xib */; };
+		F00F3B631778E63C00119580 /* SLElementStateTestScrollViewCases.xib in Resources */ = {isa = PBXBuildFile; fileRef = F00F3B621778E63C00119580 /* SLElementStateTestScrollViewCases.xib */; };
+		F00F3B6717790B4C00119580 /* SLStaticElementTestScrollView.xib in Resources */ = {isa = PBXBuildFile; fileRef = F00F3B6617790B4C00119580 /* SLStaticElementTestScrollView.xib */; };
 		F016493D16D42E3C000AEB50 /* SLTestController+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = F016493B16D42E3C000AEB50 /* SLTestController+Internal.h */; };
 		F01B2B6D16D2C55900DBA391 /* SLElementMatchingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F01B2B6A16D2C55900DBA391 /* SLElementMatchingTest.m */; };
 		F01B2B6E16D2C55900DBA391 /* SLElementMatchingTestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F01B2B6B16D2C55900DBA391 /* SLElementMatchingTestViewController.m */; };
@@ -234,6 +237,9 @@
 		F00800CD174C1C64001927AC /* SLPopover.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLPopover.m; sourceTree = "<group>"; };
 		F00800E0174C2E0A001927AC /* SLPopoverTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLPopoverTest.m; sourceTree = "<group>"; };
 		F00800E1174C2E0A001927AC /* SLPopoverTestViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLPopoverTestViewController.m; sourceTree = "<group>"; };
+		F00F3B5D1778E05100119580 /* SLElementTapTestScrollViewCases.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SLElementTapTestScrollViewCases.xib; sourceTree = "<group>"; };
+		F00F3B621778E63C00119580 /* SLElementStateTestScrollViewCases.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SLElementStateTestScrollViewCases.xib; sourceTree = "<group>"; };
+		F00F3B6617790B4C00119580 /* SLStaticElementTestScrollView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SLStaticElementTestScrollView.xib; sourceTree = "<group>"; };
 		F016493B16D42E3C000AEB50 /* SLTestController+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SLTestController+Internal.h"; sourceTree = "<group>"; };
 		F01B2B6A16D2C55900DBA391 /* SLElementMatchingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLElementMatchingTest.m; sourceTree = "<group>"; };
 		F01B2B6B16D2C55900DBA391 /* SLElementMatchingTestViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLElementMatchingTestViewController.m; sourceTree = "<group>"; };
@@ -652,6 +658,7 @@
 			children = (
 				F05D2B041746B55C0089DB9E /* SLStaticElementTest.m */,
 				F05D2B051746B55C0089DB9E /* SLStaticElementTestViewController.m */,
+				F00F3B6617790B4C00119580 /* SLStaticElementTestScrollView.xib */,
 			);
 			name = "SLStaticElement Tests";
 			sourceTree = "<group>";
@@ -735,6 +742,7 @@
 				F0AE4C8C16F7F92D00B2BB2B /* SLElementStateTestViewController.m */,
 				F0C27CDE1741694900335A41 /* SLElementStateTestMidpointCovered.xib */,
 				F0C27CE817416EC400335A41 /* SLElementStateTestCompletelyCovered.xib */,
+				F00F3B621778E63C00119580 /* SLElementStateTestScrollViewCases.xib */,
 			);
 			name = "SLElement State Tests";
 			sourceTree = "<group>";
@@ -754,6 +762,7 @@
 			children = (
 				F0CC7598173B097800E8F94A /* SLElementTapTest.m */,
 				F0CC7599173B097800E8F94A /* SLElementTapTestViewController.m */,
+				F00F3B5D1778E05100119580 /* SLElementTapTestScrollViewCases.xib */,
 			);
 			name = Tapping;
 			sourceTree = "<group>";
@@ -987,6 +996,9 @@
 				F0C27CDF1741694900335A41 /* SLElementStateTestMidpointCovered.xib in Resources */,
 				F0C27CE917416EC400335A41 /* SLElementStateTestCompletelyCovered.xib in Resources */,
 				F00800C9174B3349001927AC /* SLButtonTestViewController.xib in Resources */,
+				F00F3B5E1778E05100119580 /* SLElementTapTestScrollViewCases.xib in Resources */,
+				F00F3B631778E63C00119580 /* SLElementStateTestScrollViewCases.xib in Resources */,
+				F00F3B6717790B4C00119580 /* SLStaticElementTestScrollView.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Subliminal.xcodeproj/project.pbxproj
+++ b/Subliminal.xcodeproj/project.pbxproj
@@ -1272,7 +1272,6 @@
 					"\"$(BUILT_PRODUCTS_DIR)\"",
 				);
 				INFOPLIST_FILE = "Integration Tests/$(TARGET_NAME)-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				PRODUCT_NAME = "Subliminal (Integration Tests)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
@@ -1297,7 +1296,6 @@
 					"\"$(BUILT_PRODUCTS_DIR)\"",
 				);
 				INFOPLIST_FILE = "Integration Tests/$(TARGET_NAME)-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "Subliminal (Integration Tests)";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1321,7 +1319,6 @@
 					"\"$(BUILT_PRODUCTS_DIR)\"",
 				);
 				INFOPLIST_FILE = "Unit Tests/Subliminal Unit Tests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "Subliminal (Unit Tests)";
 				WRAPPER_EXTENSION = octest;
@@ -1344,7 +1341,6 @@
 					"\"$(BUILT_PRODUCTS_DIR)\"",
 				);
 				INFOPLIST_FILE = "Unit Tests/Subliminal Unit Tests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "Subliminal (Unit Tests)";
 				WRAPPER_EXTENSION = octest;

--- a/Supporting Files/CI/set_simulator_version
+++ b/Supporting Files/CI/set_simulator_version
@@ -19,23 +19,28 @@
 #
 
 
-# `set_simulator_device` sets the device simulated by the iOS Simulator to the specified type.
+# `set_simulator_version` sets the SDK used by the iOS Simulator to the specified version.
 # Execute `set_simulator_device` with no arguments to print usage.
 
 print_usage_and_fail () {
-	echo "usage: set_simulator_device <device>"
-	echo "  <device>\tA device type like \"iPhone\"."
-	echo "          \tAcceptable types are listed in the iPhone Simulator's \"Hardware -> Device\" menu."
+	echo "usage: set_simulator_version <sdk_version>"
+	echo "  <sdk_version>\tA string like \"5.1\" specifying the simulator SDK version to use."
 	exit 1
 }
 
-DEVICE=$1
-if [[ -z "$DEVICE" ]]; then
+SDK=$1
+if [[ -z "$SDK" ]]; then
 	print_usage_and_fail
 fi
 
-# Change device type
-defaults write com.apple.iphonesimulator SimulateDevice "$DEVICE"
+# Set new SDK root
+# The quoting of "xcode-select" is just so that "select" doesn't mess up this file's syntax highlighting
+SDK_ROOT=`find "$('xcode-select' -print-path)" -type d -iname "iphonesimulator$SDK.sdk"`
+if [[ -z "$SDK_ROOT" ]]; then
+	echo "Error: Simulator SDK $SDK not found."
+	exit 1
+fi
+defaults write com.apple.iphonesimulator currentSDKRoot "$SDK_ROOT"
 
 # Restart simulator
 killall "iPhone Simulator" 2> /dev/null

--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -31,7 +31,7 @@ subliminal-test (-project <project_path> | -workspace <workspace_path>)
 		( -sim_device <device_type> | -hw_id <udid> )
 		(-login_password <password> | --live)
 		[-build_tool <tool_name>] [-scheme <scheme_name>] [-sdk <sdk>] [-replacement_bundle_id <id>] [--quiet_build]
-		[-timeout <timeout>] [-output <output_dir>] 
+		[-sim_version <version>] [-timeout <timeout>] [-output <output_dir>] 
 		[-e <variable> <value>]
 
 \`subliminal-test\` builds a scheme contained in an Xcode project or Xcode workspace,
@@ -70,13 +70,22 @@ Required arguments:
 	-hw_id <udid>			The UDID of the hardware to target.
 					Either this or \`-sim_device\` must be specified.
 
-	-login_password <password>	The current user's login password. When instruments is launched, it may ask 
-					for permission to take control of your application (http://openradar.appspot.com/radar?id=1544403). 
-					To authorize instruments during an un-attended run, this script requires the current user's password.
-					When running this script live, \`--live\` may be specified instead.
+	-login_password <password>	The current user's login password. This permits 
+					this script to work around several bugs in Apple's \`instruments\` 
+					tool while running un-attended. The password is used: 
+
+					  1. To authorize \`instruments\` to take control of your application if 
+					     it asks for such permission when launched: http://openradar.appspot.com/radar?id=1544403.
+					  2. To temporarily modify the Xcode folder to force \`instruments\` 
+					     to use the specified SDK to run the tests, where it otherwise 
+					     would only use the latest SDK installed: http://openradar.appspot.com/radar?id=3107401.
+
+					If a developer will be attending the tests as they execute, 
+					they may specify \`--live\` rather than provide their password.
 
 	--live				Indicates that this script is being attended by a developer who can 
-					enter their password if instruments asks for authorization. For this script 
+					enter their password to authorize instruments and/or to disable the SDKs 
+					other than that specified by \`-sim_version\`. For this script 
 					to run un-attended, the current user's login password must be specified
 					using \`-login_password\`.
 
@@ -91,10 +100,11 @@ Optional build arguments:
 					Defaults to \"Release\".
 
 	-sdk <sdk>			The SDK to use to build the specified project or workspace.
-					This should be an iPhone Simulator SDK if \`-sim_device\` is specified, 
-					or an iOS device SDK if \`-hw_id\` is specified. Defaults to \"iphonesimulator\" 
-					(the latest iPhone Simulator SDK) if \`-sim_device\` is specified, 
-					or \"iphoneos\" (the latest iOS device SDK) if \`-hw_id\` is specified.
+					This should be an iOS Simulator SDK if \`-sim_device\` is specified, 
+					or an iOS device SDK if \`-hw_id\` is specified. Defaults to 
+					\"iphonesimulator\" (the latest iOS Simulator SDK installed) 
+					if \`-sim_device\` is specified, or \"iphoneos\" (the latest 
+					iOS device SDK) if \`-hw_id\` is specified.
 
 	-replacement_bundle_id <id>	The identifier to use to overwrite the product's bundle identifier.
 					When testing in-app purchase, this must be the identifier of your main app.
@@ -110,13 +120,23 @@ Optional build arguments:
 					log output entirely, by using \`xctool\` as a build tool.
 
 Optional testing arguments:
+	-sim_version <version>		The version of the iOS Simulator SDK to test with, 
+					e.g. 5.1 or 6.1. Defaults to the latest iOS Simulator SDK 
+					installed. Ignored if \`-sim_device\` is not specified.
+
+					Note that the iOS Simulator does not accept certain combinations 
+					of device type and SDK, e.g. \"iPhone (Retina 4-inch)\" 
+					and \"5.1\".
+
 	-timeout <timeout>		The maximum duration for which to run the tests before aborting.
 					Specified in milliseconds and as a number rather than a string. Defaults to infinite.
 
 	-output <output_dir>		The directory to which to save Instruments' output, to aid in debugging test failures:
-					  * the run log, as an XML plist;
+
+					  * the run log, as an XML \`.plist\`;
 					  * screenshots taken when warnings or errors are logged;
-					  * and the run's .trace file, which can be opened in the Instruments GUI to view the run log and the screenshots.
+					  * and the run's \`.trace\` file, which can be opened in the Instruments GUI to view the run log and the screenshots.
+
 					Has no default value.
 
 	--verbose_logging		Enables UIAutomation's debug logs, which record every user interaction simulated 
@@ -157,7 +177,7 @@ case $1 in
 		shift 1;;
 
 	# Set argument, wait for value
-    -project|-workspace|-sim_device|-hw_id|-login_password|-build_tool|-scheme|-configuration|-sdk|-replacement_bundle_id|-timeout|-output|-e)
+    -project|-workspace|-sim_device|-hw_id|-login_password|-build_tool|-scheme|-configuration|-sdk|-replacement_bundle_id|-sim_version|-timeout|-output|-e)
 		if [[ -n "$CURRENT_ARG" ]]; then
 			echo "Missing value for argument: $CURRENT_ARG"
 			print_usage_and_fail
@@ -204,18 +224,98 @@ fi
 # Enforce required args
 if [[ ( -z "$PROJECT" && -z "$WORKSPACE" ) || 
 	( -z "$SIM_DEVICE" && -z "$HW_ID" ) || 
-	( -z "$LOGIN_PASSWORD" && -z "$LIVE" )]]; then
+	( -z "$LOGIN_PASSWORD" && -z "$LIVE" ) ]]; then
 	echo "Missing required arguments"
 	print_usage_and_fail
 fi
 
+# This function allows simulator SDKs to be enabled/disabled 
+# to work around http://openradar.appspot.com/radar?id=3107401
+# It must be declared here because it is called from `cleanup_and_exit`
+enable_SDK_version_or_all () {
+	SDK_VERSION="$1"
+
+	# An SDK is disabled by changing its settings plist's extension to "disabled",
+	# causing it to be ignored by instruments
+	enable_SDK_at_path () {
+		SDK_PATH="$1"
+		ENABLE="$2"
+
+		# Modifying the Xcode folder will require authorization 
+		SUDO_INPUT=`([[ -z $LIVE ]] || ! $LIVE) && echo "-S" || echo ""`
+
+		SDK_VERSION=`echo "$SDK_PATH" | perl -pe 's|.*iphonesimulator(.+)\.sdk|$1|i'`
+		SDK_SETTINGS=`find "$SDK_PATH" -maxdepth 1 -name "SDKSettings.*"`
+		if ! $ENABLE && [[ "$SDK_SETTINGS" == *.plist ]]; then
+			echo "Disabling SDK $SDK_VERSION by changing the extension of \`$SDK_SETTINGS\` to \`*.disabled\`..."
+
+			# If the user did not specify a login password, this will just print a newline
+			printf "$LOGIN_PASSWORD\n" | sudo $SUDO_INPUT mv "$SDK_SETTINGS" "$SDK_PATH/SDKSettings.disabled"
+		elif $ENABLE && [[ "$SDK_SETTINGS" == *.disabled ]]; then
+			echo "Re-enabling SDK $SDK_VERSION by changing the extension of \`$SDK_SETTINGS\` back to \`*.plist\`..."
+
+			printf "$LOGIN_PASSWORD\n" | sudo $SUDO_INPUT mv "$SDK_SETTINGS" "$SDK_PATH/SDKSettings.plist"
+		fi
+	}
+	# so that the subshell used by find -exec can call this function
+	export -f enable_SDK_at_path
+	export LOGIN_PASSWORD
+	export LIVE
+
+	# If a SDK version is passed, disable all other SDKs 
+	if [[ -n "$SDK_VERSION" ]]; then
+		# The quoting of "xcode-select" is just so that "select" doesn't mess up this file's syntax highlighting
+		find "$('xcode-select' -print-path)" \
+			-iname "iphonesimulator*.sdk" -and -not -iname "iphonesimulator${SDK_VERSION}.sdk" \
+			-exec bash -c 'enable_SDK_at_path "$0" $1' {} false ';'
+	else
+		# Otherwise, (re)enable all SDKs
+		find "$('xcode-select' -print-path)" \
+			-iname "iphonesimulator*.sdk" \
+			-exec bash -c 'enable_SDK_at_path "$0" $1' {} true ';'
+	fi
+}
+
 # This function allows the script to abort at any point below without duplicating cleanup logic
 cleanup_and_exit () {
+	# Remove temporary files
 	[[ -n "$BUILD_DIR" ]] && rm -rf "$BUILD_DIR"
 	[[ -n "$BUILD_LOG" ]] && rm -rf "$BUILD_LOG"
 	[[ -n "$RUN_DIR" ]] && rm -rf "$RUN_DIR"
+
+	# Re-enable all simulator SDKs if necessary
+	echo ""
+	enable_SDK_version_or_all
+	echo ""
+	kill AUTHORIZE_INSTRUMENTS_PID 2> /dev/null
+
+	# Reset UIAutomation's debug logging if necessary
+	if [[ -z $VERBOSE_LOGGING ]] || ! $VERBOSE_LOGGING; then
+		if [[ -n "$VERBOSE_LOGGING_SETTING" ]]; then
+			defaults write com.apple.dt.InstrumentsCLI UIAVerboseLogging "$VERBOSE_LOGGING_SETTING"
+		else
+			defaults delete com.apple.dt.InstrumentsCLI UIAVerboseLogging 2> /dev/null
+		fi
+	fi
+
+	if [[ -n "$SIM_DEVICE" ]]; then
+		# Reset the simulator if the bundle identifier was replaced
+		# due to the risk of collision
+		if [[ -n "$REPLACEMENT_BUNDLE_ID" ]]; then
+			echo "\nResetting simulator content and settings because bundle identifier was replaced..."
+			"$SCRIPT_DIR/reset_simulator"
+			if [ $? -eq 0 ]; then
+				echo "Successfully reset iOS Simulator."
+			else
+				echo "\nERROR: Could not reset the simulator."
+			fi
+		fi
+	fi
+
 	exit $1
 }
+trap "cleanup_and_exit 1" SIGINT SIGTERM
+
 
 ### Build app
 QUIETLY=`[[ -e "$BUILD_LOG" ]] && echo " (quietly)" || echo ""`
@@ -244,7 +344,7 @@ if [[ -n "$SIM_DEVICE" ]]; then
 			;;
 		*)
 			echo "\nERROR: Unrecognized device type."
-			exit 1
+			cleanup_and_exit 1
 			;;
 	esac
 	TARGETED_DEVICE_FAMILY_ARG="TARGETED_DEVICE_FAMILY=$DEVICE_FAMILY"
@@ -282,7 +382,7 @@ build_base_command () {
 if [ $? -ne 0 ]; then
 	[[ -e "$BUILD_LOG" ]] && cat "$BUILD_LOG"
 
-	echo "\n\nERROR: Could not build application."
+	echo "\nERROR: Could not build application."
 	cleanup_and_exit 1
 fi
 
@@ -297,21 +397,12 @@ if [[ -n "$REPLACEMENT_BUNDLE_ID" ]]; then
 	defaults write "$INFO_PLIST" CFBundleIdentifier "$REPLACEMENT_BUNDLE_ID"
 fi
 
+
 ### Prepare to install app
 echo "\n\nPreparing to install app..."
 
 if [[ -n "$SIM_DEVICE" ]]; then
-	# Reset the simulator
 	SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
-
-	echo "\nResetting simulator content and settings..."
-	"$SCRIPT_DIR/reset_simulator"
-	if [ $? -eq 0 ]; then
-		echo "Successfully reset iOS Simulator."
-	else
-		echo "\n\nERROR: Could not reset the simulator."
-		cleanup_and_exit 1
-	fi
 
 	# Set the simulator's device type
 	echo "\nSetting simulator device type..."
@@ -319,7 +410,42 @@ if [[ -n "$SIM_DEVICE" ]]; then
 	if [ $? -eq 0 ]; then
 		echo "Successfully set simulator device type."
 	else
-		echo "\n\nERROR: Could not set the simulator's device type."
+		echo "\nERROR: Could not set the simulator's device type."
+		cleanup_and_exit 1
+	fi
+
+	# Set the simulator's version if specified
+	if [[ -n "$SIM_VERSION" ]]; then
+		echo "\nSetting simulator version..."
+
+		"$SCRIPT_DIR/set_simulator_version" "$SIM_VERSION"
+		if [ $? -ne 0 ]; then
+			echo "\nERROR: Could not set the simulator's version."
+			cleanup_and_exit 1
+		fi
+
+		# By default, the instruments command-line tool 
+		# always runs using the latest SDK
+		# http://stackoverflow.com/questions/12836129/launch-a-specific-hardware-version-of-ios-simulator-using-instruments-command-li)
+		# We must disable the SDKs other than the one we're targeting 
+		# to force it to use the simulator's current setting
+		enable_SDK_version_or_all "$SIM_VERSION"
+
+		echo "\nSuccessfully set simulator version."
+	else
+		# fall back on instruments' default behavior
+		echo "\nSimulator version not specified. Defaulting to latest simulator installed."
+	fi
+
+	# Reset the simulator
+	# This has got to be done after setting the simulator's version
+	# so that we wipe the appropriate content and settings
+	echo "\nResetting simulator content and settings..."
+	"$SCRIPT_DIR/reset_simulator"
+	if [ $? -eq 0 ]; then
+		echo "Successfully reset iOS Simulator."
+	else
+		echo "\nERROR: Could not reset the simulator."
 		cleanup_and_exit 1
 	fi
 fi
@@ -327,12 +453,13 @@ fi
 # Set paths to save Instruments' output (at least temporarily)
 RUN_DIR=`mktemp -d /tmp/subliminal-test.run.XXXXXX`
 if [ $? -ne 0 ]; then
-	echo "\n\nERROR: Could not create temporary test results directory."
+	echo "\nERROR: Could not create temporary test results directory."
 	cleanup_and_exit 1
 fi
 TRACE_FILE="$RUN_DIR/Integration Tests.trace"
 RESULTS_DIR="$RUN_DIR/Automation Results"
 mkdir "$RESULTS_DIR"
+
 
 ### Launch tests
 echo "\n\nLaunching tests...\n"
@@ -349,8 +476,8 @@ if [[ -z $LIVE ]] || ! $LIVE; then
 	# First attempt to authorize instruments when it is launched: 
 	# in the background, monitor for, and dismiss, the dialog it shows
 	osascript "$SCRIPT_DIR/authorize_instruments.scpt" "$LOGIN_PASSWORD" &
-	# Kill the process when the parent script ends
-	trap "kill $!" SIGINT SIGTERM EXIT
+	# Track pid to be killed when the parent script ends
+	AUTHORIZE_INSTRUMENTS_PID=$!
 fi
  
 # Second attempt (in case the dialog does not show, as in certain CI environments 
@@ -371,29 +498,6 @@ printf "$LOGIN_PASSWORD\n" | xcrun instruments\
 	"$APP"\
 	-e UIARESULTSPATH "$RESULTS_DIR"
 
-# Reset UIAutomation's debug logging if necessary
-if [[ -z $VERBOSE_LOGGING ]] || ! $VERBOSE_LOGGING; then
-	if [[ -n "$VERBOSE_LOGGING_SETTING" ]]; then
-		defaults write com.apple.dt.InstrumentsCLI UIAVerboseLogging "$VERBOSE_LOGGING_SETTING"
-	else
-		defaults delete com.apple.dt.InstrumentsCLI UIAVerboseLogging
-	fi
-fi
-
-if [[ -n "$SIM_DEVICE" ]]; then
-	# Reset the simulator again if the bundle identifier was replaced
-	# due to the risk of collision
-	if [[ -n "$REPLACEMENT_BUNDLE_ID" ]]; then
-		echo "\nResetting simulator content and settings again because bundle identifier was replaced..."
-		"$SCRIPT_DIR/reset_simulator"
-		if [ $? -eq 0 ]; then
-			echo "Successfully reset iOS Simulator."
-		else
-			echo "\nERROR: Could not reset the simulator."
-			# Don't fail at this point, since the tests ran
-		fi
-	fi
-fi
 
 ### Process results
 echo "\n\nProcessing results..."
@@ -403,12 +507,12 @@ RESULT_LOG="$RESULTS_DIR/Run 1/Automation Results.plist"
 TEST_STATUS=0
 grep -q "This was a focused run." "$RESULT_LOG"
 if [ $? -eq 0 ]; then
-	echo "\n\nERROR: Tests were committed with focus--fewer test cases may have run than normal."
+	echo "\nERROR: Tests were committed with focus--fewer test cases may have run than normal."
 	TEST_STATUS=1
 else
 	OVERALL_RESULT=`grep "Testing finished" "$RESULT_LOG"`
 	if [[ -z "$OVERALL_RESULT" ]]; then
-		echo "\n\nERROR: Tests did not finish."
+		echo "\nERROR: Tests did not finish."
 		TEST_STATUS=1
 	else
 		NUMBER_OF_FAILURES=`echo "$OVERALL_RESULT" | sed -E 's|.+with ([0-9]+) failure.+|\1|'`

--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -257,14 +257,10 @@ if [ $? -ne 0 ]; then
 	cleanup_and_exit 1
 fi
 
-# build in a subshell to conditionally redirect its output (and only its output)
-# to the build log (if one was created because --quiet_build was specified)
-(
-	[[ -e "$BUILD_LOG" ]] && exec >"$BUILD_LOG" 2>&1
-
-	# Don't validate the product (its entitlements etc.)
-	# --this should not be necessary in the simulator
-	# and can cause problems when testing on device
+# Don't validate the product (its entitlements etc.)
+# --this should not be necessary in the simulator
+# and can cause problems when testing on device
+build_base_command () {
 	$BUILD_TOOL\
 		$BUILD_SOURCE_ARG\
 		-scheme "$SCHEME"\
@@ -272,8 +268,15 @@ fi
 		-sdk "$SDK"\
 		$TARGETED_DEVICE_FAMILY_ARG\
 		SYMROOT="$BUILD_DIR"\
-		VALIDATE_PRODUCT=NO\
-		clean build
+		VALIDATE_PRODUCT=NO $1
+}
+
+# build in a subshell to conditionally redirect its output (and only its output)
+# to the build log (if one was created because --quiet_build was specified)
+(
+	[[ -e "$BUILD_LOG" ]] && exec >"$BUILD_LOG" 2>&1
+
+	build_base_command "clean build"
 )
 
 if [ $? -ne 0 ]; then
@@ -288,7 +291,7 @@ APP=`find "$BUILD_DIR" -name "*.app"`
 
 # Change the app's bundle identifier if a replacement was specified
 if [[ -n "$REPLACEMENT_BUNDLE_ID" ]]; then
-    INFO_PLIST_PATH=`$BUILD_TOOL -project "$PROJECT" -scheme "$SCHEME" -configuration "$CONFIGURATION" -sdk "$SDK" $TARGETED_DEVICE_FAMILY_ARG -showBuildSettings | grep INFOPLIST_PATH | awk 'BEGIN {FS=" = ";} {print $2}'`
+    INFO_PLIST_PATH=`build_base_command -showBuildSettings | grep INFOPLIST_PATH | awk 'BEGIN {FS=" = ";} {print $2}'`
     INFO_PLIST_NAME=`basename "$INFO_PLIST_PATH"`
     INFO_PLIST="$APP/$INFO_PLIST_NAME"
 	defaults write "$INFO_PLIST" CFBundleIdentifier "$REPLACEMENT_BUNDLE_ID"


### PR DESCRIPTION
Changes to address some ARC and UIAutomation bugs that exhibit in iOS 5 and earlier so that the Subliminal framework will work more reliably on these older systems.

In particular, these changes allow the example app's integration tests to work correctly in the iOS 5 simulator, and the `subliminal-test` CI script to target older versions of the SDK.
