### PR TITLE
Delay the return of `-[SLDevice setOrientation:]` to ensure that UIDevice registers the new orientation.

### DIFF
--- a/Integration Tests/Tests/SLDeviceTest.m
+++ b/Integration Tests/Tests/SLDeviceTest.m
@@ -33,6 +33,13 @@
     return @"SLDeviceTestViewController";
 }
 
+- (void)tearDownTestCaseWithSelector:(SEL)testCaseSelector {
+    if (testCaseSelector == @selector(testCanRotateDevice)) {
+        [[SLDevice currentDevice] setOrientation:UIDeviceOrientationPortrait];
+    }
+    [super tearDownTestCaseWithSelector:testCaseSelector];
+}
+
 - (void)testDeactivateAppForDuration {
     // notify whoever's watching the tests that we're about to deactivate the app,
     // so they can follow along
@@ -66,8 +73,6 @@
 
 - (void)testCanRotateDevice
 {
-    [[SLDevice currentDevice] setOrientation:UIDeviceOrientationPortrait]; // Reset
-    
     const int orientationCount = 7;
     const UIDeviceOrientation orientations[orientationCount] =
     {
@@ -83,9 +88,6 @@
     for (int i=0; i<orientationCount; i++) {
         [self rotateToAndCheckOrientation:orientations[i]];
     }
-    
-    // Reset
-    [[SLDevice currentDevice] setOrientation:UIDeviceOrientationPortrait];
 }
 
 - (void)rotateToAndCheckOrientation:(UIDeviceOrientation)orientation

--- a/Sources/Classes/UIAutomation/SLDevice.m
+++ b/Sources/Classes/UIAutomation/SLDevice.m
@@ -58,6 +58,8 @@ NSString * SLUIADeviceOrientationFromUIDeviceOrientation(UIDeviceOrientation dev
 - (void)setOrientation:(UIDeviceOrientation)deviceOrientation
 {
     [[SLTerminal sharedTerminal] evalWithFormat:@"UIATarget.localTarget().setDeviceOrientation(%@)", SLUIADeviceOrientationFromUIDeviceOrientation(deviceOrientation)];
+    // Delay slightly to ensure that UIDevice registers the new orientation
+    [NSThread sleepForTimeInterval:0.1];
 }
 
 @end


### PR DESCRIPTION
Travis is exhibiting strange timing issues. It may be that in some circumstances,
`UIDevice` has not registered the new orientation by the time that
`UIATarget.setDeviceOrientation` returns.

Also ensure that the orientation will be set back to portrait even if a later rotation fails,
by moving the reset into `-tearDownTestCaseWithSelector:`.
