### PR TITLE
`+[SLTest testNamed:]` now allows the user to retrieve focused tests

### DIFF
--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -70,7 +70,13 @@ NSString *const SLTestExceptionLineNumberKey    = @"SLTestExceptionLineNumberKey
 }
 
 + (Class)testNamed:(NSString *)name {
+    NSParameterAssert(name);
+    
     Class klass = NSClassFromString(name);
+    // perhaps the test is focused
+    if (!klass) klass = NSClassFromString([SLTestFocusPrefix stringByAppendingString:name]);
+    if (!klass) klass = NSClassFromString([[SLTestFocusPrefix capitalizedString] stringByAppendingString:name]);
+    
     BOOL classIsTestClass = (class_respondsToSelector(object_getClass(klass), @selector(isSubclassOfClass:)) &&
                              [klass isSubclassOfClass:[SLTest class]]);
     return (classIsTestClass ? klass : nil);

--- a/Unit Tests/SLTestTests.m
+++ b/Unit Tests/SLTestTests.m
@@ -94,6 +94,17 @@
     STAssertNil(undefinedTestClass, @"+testNamed: should not have found a test.");
 }
 
+- (void)testTestNamedReturnsFocusedTests {   // with or without the prefix
+    Class validTestClass = [Focus_TestThatIsFocused class];
+    
+    Class resultTestClass = [SLTest testNamed:NSStringFromClass(validTestClass)];
+    STAssertEqualObjects(resultTestClass, validTestClass, @"+testNamed: should have found the test.");
+
+    NSString *unprefixedTestClassName = [NSStringFromClass(validTestClass) substringFromIndex:[SLTestFocusPrefix length]];
+    resultTestClass = [SLTest testNamed:unprefixedTestClassName];
+    STAssertEqualObjects(resultTestClass, validTestClass, @"+testNamed: should have found the test even without the prefix.");
+}
+
 #pragma mark - Abstract tests
 
 - (void)testATestIsAbstractIfItDefinesNoTestCases {


### PR DESCRIPTION
without specifying the focus prefix.

Previously, `testNamed:` would fail to lookup a test by its regular name
while that test was focused.
