### PR TITLE
Ensure that tab bars are included in accessibility paths. (fixes #41)

### DIFF
--- a/Integration Tests/Tests/SLElementMatchingTest.m
+++ b/Integration Tests/Tests/SLElementMatchingTest.m
@@ -298,6 +298,15 @@
                  @"Could not match button in popover.");
 }
 
+#pragma mark - Tab bar buttons
+
+- (void)testMatchingTabBarButtons {
+    NSString *actualLabel, *expectedLabel = @"Favorites";
+    SLButton *favoritesButton = [SLButton elementWithAccessibilityLabel:expectedLabel];
+    SLAssertNoThrow(actualLabel = [UIAElement(favoritesButton) label], @"Could not retrieve button's label.");
+    SLAssertTrue([actualLabel isEqualToString:expectedLabel], @"Did not match button as expected.");
+}
+
 #pragma mark - Internal tests
 
 // Subliminal replaces the accessibility identifiers of objects in the accessibility

--- a/Integration Tests/Tests/SLElementMatchingTestViewController.m
+++ b/Integration Tests/Tests/SLElementMatchingTestViewController.m
@@ -142,7 +142,8 @@
         (testCase == @selector(testSubliminalOnlyReplacesAccessibilityIdentifiersOfElementsInvolvedInMatch)) ||
         (testCase == @selector(testSubliminalRestoresAccessibilityIdentifiersAfterMatching)) ||
         (testCase == @selector(testSubliminalRestoresAccessibilityIdentifiersAfterMatchingEvenIfActionThrows)) ||
-        (testCase == @selector(testMatchingPopoverChildElement_iPad))) {
+        (testCase == @selector(testMatchingPopoverChildElement_iPad)) ||
+        (testCase == @selector(testMatchingTabBarButtons))) {
         return @"SLElementMatchingTestViewController";
     } else if ((testCase == @selector(testMatchingTableViewCellTextLabel)) ||
                (testCase == @selector(testMatchingTableViewCellWithCombinedLabel)) ||

--- a/Integration Tests/Tests/SLElementMatchingTestViewController.xib
+++ b/Integration Tests/Tests/SLElementMatchingTestViewController.xib
@@ -2,9 +2,9 @@
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1552</int>
-		<string key="IBDocument.SystemVersion">12D78</string>
+		<string key="IBDocument.SystemVersion">12E55</string>
 		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.AppKitVersion">1187.39</string>
 		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -14,6 +14,8 @@
 			<string>IBProxyObject</string>
 			<string>IBUIButton</string>
 			<string>IBUISearchBar</string>
+			<string>IBUITabBar</string>
+			<string>IBUITabBarItem</string>
 			<string>IBUIView</string>
 		</array>
 		<array key="IBDocument.PluginDependencies">
@@ -109,6 +111,31 @@
 						<reference key="IBUIFontDescription" ref="599886630"/>
 						<reference key="IBUIFont" ref="1054917710"/>
 					</object>
+					<object class="IBUITabBar" id="416575555">
+						<reference key="NSNextResponder" ref="191373211"/>
+						<int key="NSvFlags">266</int>
+						<string key="NSFrame">{{0, 455}, {320, 49}}</string>
+						<reference key="NSSuperview" ref="191373211"/>
+						<reference key="NSWindow"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<object class="NSColor" key="IBUIBackgroundColor">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MCAwAA</bytes>
+						</object>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<array class="NSMutableArray" key="IBUIItems">
+							<object class="IBUITabBarItem" id="24305424">
+								<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+								<reference key="IBUITabBar" ref="416575555"/>
+								<int key="IBUISystemItemIdentifier">1</int>
+							</object>
+							<object class="IBUITabBarItem" id="692875694">
+								<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+								<reference key="IBUITabBar" ref="416575555"/>
+								<int key="IBUISystemItemIdentifier">0</int>
+							</object>
+						</array>
+					</object>
 				</array>
 				<string key="NSFrame">{{0, 64}, {320, 504}}</string>
 				<reference key="NSSuperview"/>
@@ -195,6 +222,7 @@
 							<reference ref="21240452"/>
 							<reference ref="678913373"/>
 							<reference ref="741949669"/>
+							<reference ref="416575555"/>
 						</array>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -226,6 +254,25 @@
 						<array class="NSMutableArray" key="children"/>
 						<reference key="parent" ref="191373211"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">48</int>
+						<reference key="object" ref="416575555"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="692875694"/>
+							<reference ref="24305424"/>
+						</array>
+						<reference key="parent" ref="191373211"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">49</int>
+						<reference key="object" ref="692875694"/>
+						<reference key="parent" ref="416575555"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">50</int>
+						<reference key="object" ref="24305424"/>
+						<reference key="parent" ref="416575555"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -242,12 +289,15 @@
 						<characters key="NS.bytes"/>
 					</object>
 				</object>
+				<string key="48.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="49.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="50.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 			</dictionary>
 			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">47</int>
+			<int key="maxID">50</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
@@ -316,6 +316,13 @@
 @end
 
 
+@implementation UITabBar (SLAccessibilityHierarchy)
+- (BOOL)classForcesPresenceInAccessibilityHierarchy {
+    return YES;
+}
+@end
+
+
 @implementation UIToolbar (SLAccessibilityHierarchy)
 - (BOOL)classForcesPresenceInAccessibilityHierarchy {
     return YES;


### PR DESCRIPTION
`UITabBar` is a class that forces its instances' presence in the accessibility hierarchy
even though they are not themselves accessible elements. Without including it in the
hierarchy, tab bar buttons could not be manipulated by Subliminal.
