### PR TITLE
'const' fix and support for specifying retina devices for subliminal-test

### DIFF
--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -348,7 +348,7 @@
  @param filename A filename, i.e. the last component of the `__FILE__` macro's expansion.
  @param lineNumber A line number, i.e. the `__LINE__` macro's expansion.
  */
-- (void)recordLastKnownFile:(char *)filename line:(int)lineNumber;
+- (void)recordLastKnownFile:(const char *)filename line:(int)lineNumber;
 
 /**
  Records the current filename and line number and returns its argument.

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -330,7 +330,7 @@ NSString *const SLTestExceptionLineNumberKey    = @"SLTestExceptionLineNumberKey
     [NSThread sleepForTimeInterval:interval];
 }
 
-- (void)recordLastKnownFile:(char *)filename line:(int)lineNumber {
+- (void)recordLastKnownFile:(const char *)filename line:(int)lineNumber {
     _lastKnownFilename = [@(filename) lastPathComponent];
     _lastKnownLineNumber = lineNumber;
 }

--- a/Supporting Files/CI/set_simulator_device
+++ b/Supporting Files/CI/set_simulator_device
@@ -35,7 +35,7 @@ if [[ -z "$DEVICE" ]]; then
 fi
 
 # Change device type
-defaults write com.apple.iphonesimulator SimulateDevice "$DEVICE"
+defaults write com.apple.iphonesimulator SimulateDevice "'$DEVICE'"
 
 # Restart simulator
 killall "iPhone Simulator" 2> /dev/null


### PR DESCRIPTION
This replaces previous pull request ( https://github.com/inkling/Subliminal/pull/43 )
