### PR TITLE
Ensure that action sheets are included in accessibility paths. (refs #46...

### DIFF
--- a/Integration Tests/Tests/SLElementMatchingTest.m
+++ b/Integration Tests/Tests/SLElementMatchingTest.m
@@ -48,6 +48,8 @@
 - (void)tearDownTestCaseWithSelector:(SEL)testCaseSelector {
     if (testCaseSelector == @selector(testMatchingPopoverChildElement_iPad)) {
         SLAskApp(hidePopover);
+    } else if (testCaseSelector == @selector(testMatchingActionSheetButtons)) {
+        SLAskApp(hideActionSheet);
     }
     [super tearDownTestCaseWithSelector:testCaseSelector];
 }
@@ -304,6 +306,17 @@
     NSString *actualLabel, *expectedLabel = @"Favorites";
     SLButton *favoritesButton = [SLButton elementWithAccessibilityLabel:expectedLabel];
     SLAssertNoThrow(actualLabel = [UIAElement(favoritesButton) label], @"Could not retrieve button's label.");
+    SLAssertTrue([actualLabel isEqualToString:expectedLabel], @"Did not match button as expected.");
+}
+
+#pragma mark - Action sheets
+
+- (void)testMatchingActionSheetButtons {
+    SLAskApp(showActionSheet);
+
+    NSString *actualLabel, *expectedLabel = @"Cancel";
+    SLButton *cancelButton = [SLButton elementWithAccessibilityLabel:expectedLabel];
+    SLAssertNoThrow(actualLabel = [UIAElement(cancelButton) label], @"Could not retrieve button's label.");
     SLAssertTrue([actualLabel isEqualToString:expectedLabel], @"Did not match button as expected.");
 }
 

--- a/Integration Tests/Tests/SLElementMatchingTest.m
+++ b/Integration Tests/Tests/SLElementMatchingTest.m
@@ -46,7 +46,9 @@
 }
 
 - (void)tearDownTestCaseWithSelector:(SEL)testCaseSelector {
-    if (testCaseSelector == @selector(testMatchingPopoverChildElement_iPad)) {
+    // popovers must be hidden before they are deallocated or else will raise an exception
+    if ((testCaseSelector == @selector(testMatchingPopoverChildElement_iPad)) ||
+        (testCaseSelector == @selector(testMatchingButtonsOfActionSheetsInPopovers_iPad))){
         SLAskApp(hidePopover);
     } else if (testCaseSelector == @selector(testMatchingActionSheetButtons)) {
         SLAskApp(hideActionSheet);
@@ -315,6 +317,18 @@
     SLAskApp(showActionSheet);
 
     NSString *actualLabel, *expectedLabel = @"Cancel";
+    SLButton *cancelButton = [SLButton elementWithAccessibilityLabel:expectedLabel];
+    SLAssertNoThrow(actualLabel = [UIAElement(cancelButton) label], @"Could not retrieve button's label.");
+    SLAssertTrue([actualLabel isEqualToString:expectedLabel], @"Did not match button as expected.");
+}
+
+// Somewhat of an internal test--when a popover shows an action sheet,
+// that changes the popover's accessibility structure in a way that
+// once caused Subliminal to misidentify the action sheet
+- (void)testMatchingButtonsOfActionSheetsInPopovers_iPad {
+    SLAskApp(showPopoverWithActionSheet);
+
+    NSString *actualLabel, *expectedLabel = @"Popover Cancel";
     SLButton *cancelButton = [SLButton elementWithAccessibilityLabel:expectedLabel];
     SLAssertNoThrow(actualLabel = [UIAElement(cancelButton) label], @"Could not retrieve button's label.");
     SLAssertTrue([actualLabel isEqualToString:expectedLabel], @"Did not match button as expected.");

--- a/Integration Tests/Tests/SLElementMatchingTestViewController.m
+++ b/Integration Tests/Tests/SLElementMatchingTestViewController.m
@@ -147,7 +147,8 @@
         (testCase == @selector(testSubliminalRestoresAccessibilityIdentifiersAfterMatchingEvenIfActionThrows)) ||
         (testCase == @selector(testMatchingPopoverChildElement_iPad)) ||
         (testCase == @selector(testMatchingTabBarButtons)) ||
-        (testCase == @selector(testMatchingActionSheetButtons))) {
+        (testCase == @selector(testMatchingActionSheetButtons)) ||
+        (testCase == @selector(testMatchingButtonsOfActionSheetsInPopovers_iPad))) {
         return @"SLElementMatchingTestViewController";
     } else if ((testCase == @selector(testMatchingTableViewCellTextLabel)) ||
                (testCase == @selector(testMatchingTableViewCellWithCombinedLabel)) ||
@@ -172,6 +173,7 @@
         [[SLTestController sharedTestController] registerTarget:self forAction:@selector(barButtonIdentifier)];
         [[SLTestController sharedTestController] registerTarget:self forAction:@selector(webViewDidFinishLoad)];
         [[SLTestController sharedTestController] registerTarget:self forAction:@selector(showPopover)];
+        [[SLTestController sharedTestController] registerTarget:self forAction:@selector(showPopoverWithActionSheet)];
         [[SLTestController sharedTestController] registerTarget:self forAction:@selector(showActionSheet)];
         [[SLTestController sharedTestController] registerTarget:self forAction:@selector(hideActionSheet)];
     }
@@ -368,7 +370,7 @@
     return @(_webViewDidFinishLoad);
 }
 
-- (void)showPopover {
+- (void)showPopoverWithActionSheet:(BOOL)showActionSheet {
     // Inception!
     SLElementMatchingTestViewController *contentViewController = [[SLElementMatchingTestViewController alloc] initWithTestCaseWithSelector:self.testCase];
 
@@ -381,6 +383,23 @@
 
     // register this here vs. in init so the controller we just presented doesn't steal it
     [[SLTestController sharedTestController] registerTarget:self forAction:@selector(hidePopover)];
+
+    if (showActionSheet) {
+        UIActionSheet *testSheet = [[UIActionSheet alloc] initWithTitle:@"Test Sheet"
+                                                               delegate:nil
+                                                      cancelButtonTitle:@"Popover Cancel"
+                                                 destructiveButtonTitle:@"Destruct"
+                                                      otherButtonTitles:nil];
+        [testSheet showInView:_popoverController.contentViewController.view];
+    }
+}
+
+- (void)showPopover {
+    [self showPopoverWithActionSheet:NO];
+}
+
+- (void)showPopoverWithActionSheet {
+    [self showPopoverWithActionSheet:YES];
 }
 
 - (void)hidePopover {

--- a/Integration Tests/Tests/SLElementMatchingTestViewController.m
+++ b/Integration Tests/Tests/SLElementMatchingTestViewController.m
@@ -114,6 +114,7 @@
 @property (weak, nonatomic) IBOutlet UIButton *barButton;
 @property (weak, nonatomic) IBOutlet UISearchBar *searchBar;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
+@property (weak, nonatomic) IBOutlet UITabBar *tabBar;
 
 @end
 
@@ -127,6 +128,8 @@
     BOOL _webViewDidFinishLoad;
 
     UIPopoverController *_popoverController;
+
+    UIActionSheet *_actionSheet;
 }
 
 + (NSString *)nibNameForTestCase:(SEL)testCase {
@@ -143,7 +146,8 @@
         (testCase == @selector(testSubliminalRestoresAccessibilityIdentifiersAfterMatching)) ||
         (testCase == @selector(testSubliminalRestoresAccessibilityIdentifiersAfterMatchingEvenIfActionThrows)) ||
         (testCase == @selector(testMatchingPopoverChildElement_iPad)) ||
-        (testCase == @selector(testMatchingTabBarButtons))) {
+        (testCase == @selector(testMatchingTabBarButtons)) ||
+        (testCase == @selector(testMatchingActionSheetButtons))) {
         return @"SLElementMatchingTestViewController";
     } else if ((testCase == @selector(testMatchingTableViewCellTextLabel)) ||
                (testCase == @selector(testMatchingTableViewCellWithCombinedLabel)) ||
@@ -168,6 +172,8 @@
         [[SLTestController sharedTestController] registerTarget:self forAction:@selector(barButtonIdentifier)];
         [[SLTestController sharedTestController] registerTarget:self forAction:@selector(webViewDidFinishLoad)];
         [[SLTestController sharedTestController] registerTarget:self forAction:@selector(showPopover)];
+        [[SLTestController sharedTestController] registerTarget:self forAction:@selector(showActionSheet)];
+        [[SLTestController sharedTestController] registerTarget:self forAction:@selector(hideActionSheet)];
     }
     return self;
 }
@@ -379,6 +385,19 @@
 
 - (void)hidePopover {
     [_popoverController dismissPopoverAnimated:NO];
+}
+
+- (void)showActionSheet {
+    _actionSheet = [[UIActionSheet alloc] initWithTitle:@"Test Sheet"
+                                               delegate:nil
+                                      cancelButtonTitle:@"Cancel"
+                                 destructiveButtonTitle:@"Destruct"
+                                      otherButtonTitles:nil];
+    [_actionSheet showFromTabBar:self.tabBar];
+}
+
+- (void)hideActionSheet {
+    [_actionSheet dismissWithClickedButtonIndex:0 animated:NO];
 }
 
 @end

--- a/Integration Tests/Tests/SLElementMatchingTestViewController.xib
+++ b/Integration Tests/Tests/SLElementMatchingTestViewController.xib
@@ -94,7 +94,7 @@
 						<string key="NSFrame">{{20, 167}, {280, 44}}</string>
 						<reference key="NSSuperview" ref="191373211"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
+						<reference key="NSNextKeyView" ref="416575555"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -117,6 +117,7 @@
 						<string key="NSFrame">{{0, 455}, {320, 49}}</string>
 						<reference key="NSSuperview" ref="191373211"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
 							<int key="NSColorSpace">3</int>
@@ -205,6 +206,14 @@
 						<reference key="destination" ref="741949669"/>
 					</object>
 					<int key="connectionID">37</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">tabBar</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="416575555"/>
+					</object>
+					<int key="connectionID">51</int>
 				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -297,7 +306,7 @@
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">50</int>
+			<int key="maxID">51</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -308,6 +317,7 @@
 						<string key="barButton">UIButton</string>
 						<string key="fooButton">UIButton</string>
 						<string key="searchBar">UISearchBar</string>
+						<string key="tabBar">UITabBar</string>
 						<string key="tableView">UITableView</string>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
@@ -322,6 +332,10 @@
 						<object class="IBToOneOutletInfo" key="searchBar">
 							<string key="name">searchBar</string>
 							<string key="candidateClassName">UISearchBar</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="tabBar">
+							<string key="name">tabBar</string>
+							<string key="candidateClassName">UITabBar</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="tableView">
 							<string key="name">tableView</string>

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
@@ -211,10 +211,6 @@
     }
     if (isTableViewSectionElement) return YES;
 
-    // _UIPopoverView is identified by its parent's label.
-    BOOL isPopover = [[parent accessibilityLabel] isEqualToString:@"dismiss popup"];
-    if (isPopover) return YES;
-
     return NO;
 }
 
@@ -240,6 +236,17 @@
         }
         return children;
     }
+}
+
+- (BOOL)classForcesPresenceInAccessibilityHierarchy {
+    if ([super classForcesPresenceInAccessibilityHierarchy]) return YES;
+
+    // Identify _UIPopoverView by its first subview being a popover background view.
+    BOOL isPopover = NO;
+    if ([self.subviews count]) {
+        isPopover = [self.subviews[0] isKindOfClass:[UIPopoverBackgroundView class]];
+    }
+    return isPopover;
 }
 
 // An object is a mock view if its accessibilityIdentifier tracks

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
@@ -330,6 +330,13 @@
 @end
 
 
+@implementation UIActionSheet (SLAccessibilityHierarchy)
+- (BOOL)classForcesPresenceInAccessibilityHierarchy {
+    return YES;
+}
+@end
+
+
 @implementation UINavigationBar (SLAccessibilityHierarchy)
 - (BOOL)classForcesPresenceInAccessibilityHierarchy {
     return YES;


### PR DESCRIPTION
...)

`UIActionSheet` is a class that forces its instances' presence in the accessibility hierarchy
even though they are not themselves accessible elements. Without including it in the
hierarchy, action sheet buttons cannot be manipulated by Subliminal.
