### PR TITLE
Log uncaught exceptions as test case errors.

### DIFF
--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -174,6 +174,13 @@
                          failed:(NSUInteger *)numCasesFailed
              failedUnexpectedly:(NSUInteger *)numCasesFailedUnexpectedly;
 
+/**
+ The currently-running test case, if any.
+ 
+ This will be `nil` while the test is being set up or torn down.
+ */
+@property (nonatomic, readonly) NSString *currentTestCase;
+
 @end
 
 

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -248,6 +248,7 @@ NSString *const SLTestExceptionLineNumberKey    = @"SLTestExceptionLineNumberKey
     if (!setUpOrTearDownException) {
         NSString *test = NSStringFromClass([self class]);
         for (NSString *testCaseName in [[self class] testCasesToRun]) {
+            _currentTestCase = testCaseName;
             @autoreleasepool {
                 // all logs below use the focused name, so that the logs are consistent
                 // with what's actually running
@@ -302,6 +303,7 @@ NSString *const SLTestExceptionLineNumberKey    = @"SLTestExceptionLineNumberKey
                 }
                 numberOfCasesExecuted++;
             }
+            _currentTestCase = nil;
         }
     }
 

--- a/Sources/Classes/SLTestController.m
+++ b/Sources/Classes/SLTestController.m
@@ -49,7 +49,23 @@ static const NSTimeInterval kDefaultTimeout = 5.0;
 /// Uncaught exceptions are logged to Subliminal for visibility.
 static void SLUncaughtExceptionHandler(NSException *exception)
 {
-    NSString *exceptionMessage = [NSString stringWithFormat:@"Uncaught exception occurred: ***%@*** for reason: %@", [exception name], [exception reason]];
+    NSMutableString *exceptionMessage = [[NSMutableString alloc] initWithString:@"Uncaught exception occurred"];
+    SLTest *currentTest = [[SLTestController sharedTestController] currentTest];
+    if (currentTest) {
+        NSString *currentTestName = NSStringFromClass([currentTest class]);
+        NSString *currentTestCase = currentTest.currentTestCase;
+        if (currentTestCase) {
+            [exceptionMessage appendFormat:@" during test case \"-[%@ %@]\"", currentTestName, currentTestCase];
+        } else {
+            [exceptionMessage appendFormat:@" during test \"%@\"", currentTestName];
+        }
+    }
+    [exceptionMessage appendFormat:@": ***%@***", [exception name]];
+    NSString *exceptionReason = [exception reason];
+    if ([exceptionReason length]) {
+        [exceptionMessage appendFormat:@" for reason: %@", exceptionReason];
+    }
+    
     if ([NSThread isMainThread]) {
         // We need to wait for UIAutomation, but we can't block the main thread,
         // so we spin the run loop instead.

--- a/Sources/Classes/SLTestController.m
+++ b/Sources/Classes/SLTestController.m
@@ -37,6 +37,15 @@
 static NSUncaughtExceptionHandler *appsUncaughtExceptionHandler = NULL;
 static const NSTimeInterval kDefaultTimeout = 5.0;
 
+
+@interface SLTestController () <UIAlertViewDelegate>
+
+/// The currently-running test, if any.
+@property (nonatomic, readonly) SLTest *currentTest;
+
+@end
+
+
 /// Uncaught exceptions are logged to Subliminal for visibility.
 static void SLUncaughtExceptionHandler(NSException *exception)
 {
@@ -61,9 +70,6 @@ static void SLUncaughtExceptionHandler(NSException *exception)
     }
 }
 
-
-@interface SLTestController () <UIAlertViewDelegate>
-@end
 
 @implementation SLTestController {
     dispatch_queue_t _runQueue;
@@ -230,7 +236,7 @@ static SLTestController *__sharedController = nil;
 
         for (Class testClass in _testsToRun) {
             @autoreleasepool {
-                SLTest *test = (SLTest *)[[testClass alloc] init];
+                _currentTest = (SLTest *)[[testClass alloc] init];
 
                 NSString *testName = NSStringFromClass(testClass);
                 [[SLLogger sharedLogger] logTestStart:testName];
@@ -238,9 +244,9 @@ static SLTestController *__sharedController = nil;
                 @try {
                     NSUInteger numCasesExecuted = 0, numCasesFailed = 0, numCasesFailedUnexpectedly = 0;
 
-                    [test runAndReportNumExecuted:&numCasesExecuted
-                                           failed:&numCasesFailed
-                               failedUnexpectedly:&numCasesFailedUnexpectedly];
+                    [_currentTest runAndReportNumExecuted:&numCasesExecuted
+                                                   failed:&numCasesFailed
+                                       failedUnexpectedly:&numCasesFailedUnexpectedly];
 
                     [[SLLogger sharedLogger] logTestFinish:testName
                                       withNumCasesExecuted:numCasesExecuted
@@ -266,6 +272,8 @@ static SLTestController *__sharedController = nil;
                     _numTestsFailed++;
                 }
                 _numTestsExecuted++;
+
+                _currentTest = nil;
             }
         }
 

--- a/Supporting Files/CI/subliminal_uialog_to_junit
+++ b/Supporting Files/CI/subliminal_uialog_to_junit
@@ -54,20 +54,19 @@ def main(inputPath, outputPath):
         # NOTE: Don't change the order of "failed unexpectedly" and "failed" or
         # the regular expression matcher will always choose "failed" instead of
         # "failed unexpectedly."
-        match = re.match('^Test case "\-\[(.+) (.+)\]" (passed|failed\ unexpectedly|failed)', message)
+        match = re.match('^Test case "\-\[.+ (.+)\]" (passed|failed\ unexpectedly|failed)', message)
         if (match is not None):
-            testClassName = match.group(1)
-            testCaseName = match.group(2)
-            action = match.group(3)
-            if (testClassName is not None):
-                case = ET.SubElement(testSuite, "testcase")
-                case.set("name", testCaseName)
-                if (action == "failed"):
-                    failure = ET.SubElement(case, "failure")
-                    failure.set("message", latestErrorMessage)
-                elif (action == "failed unexpectedly"):
-                    error = ET.SubElement(case, "error")
-                    error.set("message", latestErrorMessage)
+            testCaseName = match.group(1)
+            case = ET.SubElement(testSuite, "testcase")
+            case.set("name", testCaseName)
+
+            action = match.group(2)
+            if (action == "failed"):
+                failure = ET.SubElement(case, "failure")
+                failure.set("message", latestErrorMessage)
+            elif (action == "failed unexpectedly"):
+                error = ET.SubElement(case, "error")
+                error.set("message", latestErrorMessage)
 
         tree = ET.ElementTree(root)
         tree.write(outputPath)

--- a/Supporting Files/CI/subliminal_uialog_to_junit
+++ b/Supporting Files/CI/subliminal_uialog_to_junit
@@ -46,10 +46,9 @@ def main(inputPath, outputPath):
         if (match is not None):
             testSuiteName = match.group(1)
             action = match.group(2)
-            if (testSuiteName is not None):
-                if (action == "started"):
-                    testSuite = ET.SubElement(root, "testsuite")
-                    testSuite.set("name", testSuiteName)
+            if (action == "started"):
+                testSuite = ET.SubElement(root, "testsuite")
+                testSuite.set("name", testSuiteName)
 
         # Test cases
         # NOTE: Don't change the order of "failed unexpectedly" and "failed" or

--- a/Supporting Files/CI/subliminal_uialog_to_junit
+++ b/Supporting Files/CI/subliminal_uialog_to_junit
@@ -55,7 +55,7 @@ def main(inputPath, outputPath):
         # NOTE: Don't change the order of "failed unexpectedly" and "failed" or
         # the regular expression matcher will always choose "failed" instead of
         # "failed unexpectedly."
-        match = re.match('^Test case "[\+|\-]\[(.+) (.+)\]" (passed|failed\ unexpectedly|failed)', message)
+        match = re.match('^Test case "\-\[(.+) (.+)\]" (passed|failed\ unexpectedly|failed)', message)
         if (match is not None):
             testClassName = match.group(1)
             testCaseName = match.group(2)

--- a/Supporting Files/CI/subliminal_uialog_to_junit
+++ b/Supporting Files/CI/subliminal_uialog_to_junit
@@ -67,6 +67,20 @@ def main(inputPath, outputPath):
             elif (action == "failed unexpectedly"):
                 error = ET.SubElement(case, "error")
                 error.set("message", latestErrorMessage)
+        else:
+            match = re.match('^Uncaught exception occurred during test case "\-\[.+ (.+)\]": \*\*\*(.+)\*\*\*(?: for reason: (.+))?', message)
+            if (match is not None):
+                testCaseName = match.group(1)
+                case = ET.SubElement(testSuite, "testcase")
+                case.set("name", testCaseName)
+
+                exceptionName = match.group(2)
+                exceptionReason = match.group(3);
+                exceptionMessage = "Uncaught exception occurred: ***%s***" % exceptionName
+                if (exceptionReason is not None):
+                    exceptionMessage += " for reason: %s" % exceptionReason
+                error = ET.SubElement(case, "error");
+                error.set("message", exceptionMessage)
 
         tree = ET.ElementTree(root)
         tree.write(outputPath)


### PR DESCRIPTION
Fixes #50 and generally improves debugging when reviewing test logs.
