### PR TITLE
Make SLTextField setText work with more strings

### DIFF
--- a/Integration Tests/Tests/SLTextFieldTest.m
+++ b/Integration Tests/Tests/SLTextFieldTest.m
@@ -111,9 +111,13 @@
 }
 
 - (void)testSetSearchBarText {
-    NSString *const expectedText = @"bar";
-    SLAssertNoThrow([UIAElement(_textField) setText:expectedText], @"Should not have thrown.");
-    SLAssertTrue([SLAskApp(text) isEqualToString:expectedText], @"Text was not set to expected value.");
+    NSString *const expectedText1 = @"foo";
+    SLAssertNoThrow([UIAElement(_textField) setText:expectedText1], @"Should not have thrown.");
+    SLAssertTrue([SLAskApp(text) isEqualToString:expectedText1], @"Text was not set to expected value.");
+
+    NSString *const expectedText2 = @"bar";
+    SLAssertNoThrow([UIAElement(_textField) setText:expectedText2], @"Should not have thrown.");
+    SLAssertTrue([SLAskApp(text) isEqualToString:expectedText2], @"Text was not set to expected value.");
 }
 
 - (void)testGetSearchBarText {

--- a/Integration Tests/Tests/SLTextFieldTest.m
+++ b/Integration Tests/Tests/SLTextFieldTest.m
@@ -60,9 +60,13 @@
 #pragma mark - SLTextField test cases
 
 - (void)testSetText {
-    NSString *const expectedText = @"foo";
-    SLAssertNoThrow([UIAElement(_textField) setText:expectedText], @"Should not have thrown.");
-    SLAssertTrue([SLAskApp(text) isEqualToString:expectedText], @"Text was not set to expected value.");
+    NSString *const basicExpectedText = @"Foo";
+    SLAssertNoThrow([UIAElement(_textField) setText:basicExpectedText], @"Should not have thrown.");
+    SLAssertTrue([SLAskApp(text) isEqualToString:basicExpectedText], @"Text was not set to expected value.");
+
+    NSString *const complexExpectedText = @"Foo'Bar_123>Baz<Buz";
+    SLAssertNoThrow([UIAElement(_textField) setText:complexExpectedText], @"Should not have thrown.");
+    SLAssertTrue([SLAskApp(text) isEqualToString:complexExpectedText], @"Text was not set to expected value.");
 }
 
 - (void)testSetTextWhenFieldClearsOnBeginEditing {

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLTextField.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLTextField.m
@@ -57,6 +57,8 @@
     // typeString method will fail when Automation can't find the first of those
     // "non-basic" character's keys on the keyboard, so we use setValue instead.
     if ([text rangeOfCharacterFromSet:nonBasicCharacters].location == NSNotFound) {
+        // Clear any current text before typing the new text.
+        [self waitUntilTappable:YES thenSendMessage:@"setValue('')"];
         [[SLKeyboard keyboard] typeString:text];
     } else {
         [self waitUntilTappable:YES thenSendMessage:@"setValue('%@')", [text slStringByEscapingForJavaScriptLiteral]];

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLTextField.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLTextField.m
@@ -31,6 +31,12 @@
 }
 
 - (void)setText:(NSString *)text {
+    static NSCharacterSet *nonBasicCharacters;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        nonBasicCharacters = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,. "] invertedSet];
+    });
+
     // Normally we want to tap on the view that backs this SLTextField before
     // attempting to edit the field.  That way we can be confident that the
     // view will be first responder.  The only exception is when the backing
@@ -44,7 +50,17 @@
     if (tapBeforeSettingText) {
         [self tap];
     }
-    [[SLKeyboard keyboard] typeString:text];
+
+    // If the text contains only characters that appear on the software keyboard
+    // in its default state, then we can use typeString to enter the text in the
+    // field.  If the text contains other characters then the JavaScript
+    // typeString method will fail when Automation can't find the first of those
+    // "non-basic" character's keys on the keyboard, so we use setValue instead.
+    if ([text rangeOfCharacterFromSet:nonBasicCharacters].location == NSNotFound) {
+        [[SLKeyboard keyboard] typeString:text];
+    } else {
+        [self waitUntilTappable:YES thenSendMessage:@"setValue('%@')", [text slStringByEscapingForJavaScriptLiteral]];
+    }
 }
 
 - (BOOL)matchesObject:(NSObject *)object {


### PR DESCRIPTION
Updates SLTextField's setText method so that it can handle
strings that include characters that do not appear on the
software keyboard in the software keyboard's default state.
