### PR TITLE
Execute test classes in alphanumeric order

### DIFF
--- a/Integration Tests/SLIntegrationTestsAppDelegate.m
+++ b/Integration Tests/SLIntegrationTestsAppDelegate.m
@@ -39,7 +39,7 @@
 @end
 
 @implementation SLIntegrationTestsAppDelegate {
-    NSSet *_tests;
+    NSArray *_tests;
     NSString *_terminalStartupResult;
 }
 
@@ -56,7 +56,7 @@
         // Filter the tests for the SLTestController
         // so that the SLTestsViewController only displays appropriate tests
         _tests = [SLTestController testsToRun:[SLTest allTests] withFocus:NULL];
-        rootViewController = [[SLTestsViewController alloc] initWithTests:[_tests allObjects]];
+        rootViewController = [[SLTestsViewController alloc] initWithTests:_tests];
     }
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:rootViewController];
     self.window.rootViewController = navController;

--- a/Sources/Classes/Internal/SLTestController+Internal.h
+++ b/Sources/Classes/Internal/SLTestController+Internal.h
@@ -47,6 +47,6 @@
  if any of the tests [are focused](+[SLTest isFocused]), `NO` otherwise.
  @return A filtered set of tests to run.
  */
-+ (NSSet *)testsToRun:(NSSet *)tests withFocus:(BOOL*)withFocus;
++ (NSArray *)testsToRun:(NSArray *)tests withFocus:(BOOL*)withFocus;
 
 @end

--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -51,7 +51,7 @@
 
  @return All tests (`SLTest` subclasses) linked against the current target.
  */
-+ (NSSet *)allTests;
++ (NSArray *)allTests;
 
 /**
  Returns the `SLTest` subclass with the specified name.

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -45,8 +45,8 @@ NSString *const SLTestExceptionLineNumberKey    = @"SLTestExceptionLineNumberKey
     int _lastKnownLineNumber;
 }
 
-+ (NSSet *)allTests {
-    NSMutableSet *tests = [[NSMutableSet alloc] init];
++ (NSArray *)allTests {
+    NSMutableArray *tests = [[NSMutableArray alloc] init];
     
     int numClasses = objc_getClassList(NULL, 0);
     if (numClasses > 0) {
@@ -66,7 +66,14 @@ NSString *const SLTestExceptionLineNumberKey    = @"SLTestExceptionLineNumberKey
         free(classes);
     }
     
-    return tests;
+    NSArray *sortedTests;
+    sortedTests = [tests sortedArrayUsingComparator:^NSComparisonResult(id a, id b) {
+        NSString* aName = NSStringFromClass(a);
+        NSString* bName = NSStringFromClass(b);
+        return [aName caseInsensitiveCompare:bName] == NSOrderedDescending;
+    }];
+    
+    return sortedTests;
 }
 
 + (Class)testNamed:(NSString *)name {

--- a/Sources/Classes/SLTestController.h
+++ b/Sources/Classes/SLTestController.h
@@ -78,7 +78,7 @@
  @param tests The set of tests to run.
  @param completionBlock An optional block to execute once testing has finished. 
  */
-- (void)runTests:(NSSet *)tests withCompletionBlock:(void (^)())completionBlock;
+- (void)runTests:(NSArray *)tests withCompletionBlock:(void (^)())completionBlock;
 
 @end
 

--- a/Sources/Classes/SLTestController.m
+++ b/Sources/Classes/SLTestController.m
@@ -90,7 +90,7 @@ static void SLUncaughtExceptionHandler(NSException *exception)
 @implementation SLTestController {
     dispatch_queue_t _runQueue;
     BOOL _runningWithFocus;
-    NSSet *_testsToRun;
+    NSArray *_testsToRun;
     NSUInteger _numTestsExecuted, _numTestsFailed;
     void(^_completionBlock)(void);
 
@@ -117,21 +117,20 @@ static SLTestController *__sharedController = nil;
     return __sharedController;
 }
 
-+ (NSSet *)testsToRun:(NSSet *)tests withFocus:(BOOL *)withFocus {
++ (NSArray *)testsToRun:(NSArray *)tests withFocus:(BOOL *)withFocus {
     // only run tests that are concrete...
-    NSMutableSet *testsToRun = [NSMutableSet setWithSet:tests];
+    NSMutableArray *testsToRun = [NSMutableArray arrayWithArray:tests];
     [testsToRun filterUsingPredicate:[NSPredicate predicateWithFormat:@"isAbstract == NO"]];
 
     // ...that support the current platform...
     [testsToRun filterUsingPredicate:[NSPredicate predicateWithFormat:@"supportsCurrentPlatform == YES"]];
 
     // ...and that are focused (if any remaining are focused)
-    NSSet *focusedTests = [testsToRun objectsPassingTest:^BOOL(id obj, BOOL *stop) {
-        return [obj isFocused];
-    }];
+    NSArray *focusedTests = [testsToRun filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"isFocused == YES"]];
+
     BOOL runningWithFocus = ([focusedTests count] > 0);
     if (runningWithFocus) {
-        testsToRun = [NSMutableSet setWithSet:focusedTests];
+        testsToRun = [NSMutableArray arrayWithArray:focusedTests];
     }
     if (withFocus) *withFocus = runningWithFocus;
 
@@ -229,7 +228,7 @@ static SLTestController *__sharedController = nil;
 #endif
 
     if (_runningWithFocus) {
-        SLLog(@"Focusing on test cases in specific tests: %@.", [[_testsToRun allObjects] componentsJoinedByString:@","]);
+        SLLog(@"Focusing on test cases in specific tests: %@.", [_testsToRun componentsJoinedByString:@","]);
     }
 
     [self warnIfAccessibilityInspectorIsEnabled];
@@ -237,7 +236,7 @@ static SLTestController *__sharedController = nil;
     [[SLLogger sharedLogger] logTestingStart];
 }
 
-- (void)runTests:(NSSet *)tests withCompletionBlock:(void (^)())completionBlock {
+- (void)runTests:(NSArray *)tests withCompletionBlock:(void (^)())completionBlock {
     dispatch_async(_runQueue, ^{
         _completionBlock = completionBlock;
 

--- a/Unit Tests/SLTestController+AppContextTests.m
+++ b/Unit Tests/SLTestController+AppContextTests.m
@@ -199,7 +199,7 @@
     // expect the action to be received
     [[_targetMock expect] actionTakingNoArgumentReturningVoid];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should have received action.");
 }
@@ -219,7 +219,7 @@
     // expect the action to be received with the given argument
     [[_targetMock expect] actionTakingAnArgumentReturningVoid:actionArg];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should have received action.");
 }
@@ -241,7 +241,7 @@
     // expect the action to be received, and return the expected value
     [[[_targetMock expect] andReturn:expectedReturnValue] actionTakingNoArgumentReturningAValue];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should have received action.");
 }
@@ -264,7 +264,7 @@
     // expect the action to be received with the given argument, and return the expected value
     [[[_targetMock expect] andReturn:expectedReturnValue] actionTakingAnArgumentReturningAValue:actionArg];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should have received action.");
 }
@@ -287,7 +287,7 @@
     [[_targetMock expect] actionTakingNoArgumentReturningVoid];
     [[_targetMock reject] actionTakingNoArgumentReturningVoid];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should have received action.");
 }
@@ -300,7 +300,7 @@
                         @"Should have thrown an exception because no target was registered for the action.");
     }] testOne];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
 }
 
@@ -323,7 +323,7 @@
 
     [[_targetMock expect] actionTakingNoArgumentReturningVoid];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Should have received action.");
 }
@@ -344,7 +344,7 @@
     // expect the action to be received
     [[_targetMock expect] actionTakingNoArgumentReturningVoid];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should have received action.");
 
@@ -362,7 +362,7 @@
     // expect the action to not be received
     [[_targetMock reject] actionTakingNoArgumentReturningVoid];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should not have received action, because it deregistered.");
 }
@@ -391,7 +391,7 @@
     [[_targetMock expect] actionTakingNoArgumentReturningVoid];
     [[_targetMock expect] actionTakingNoArgumentReturningAValue];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should have received actions.");
 
@@ -414,7 +414,7 @@
     [[_targetMock reject] actionTakingNoArgumentReturningVoid];
     [[_targetMock reject] actionTakingNoArgumentReturningAValue];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should not have received actions, because it deregistered.");
 }
@@ -439,7 +439,7 @@
     [[_secondTargetMock expect] actionTakingNoArgumentReturningVoid];
     [[_targetMock reject] actionTakingNoArgumentReturningVoid];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_secondTargetMock verify], @"Second target should have received action.");
     STAssertNoThrow([_targetMock verify], @"First target should not have received action.");
@@ -469,7 +469,7 @@
     // i.e it should not have been deregistered by the above call
     [[_secondTargetMock expect] actionTakingNoArgumentReturningVoid];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_secondTargetMock verify], @"Second target should have received action.");
 }
@@ -497,7 +497,7 @@
     id localTargetMock = [OCMockObject partialMockForObject:localTarget];
     [[localTargetMock expect] actionTakingNoArgumentReturningVoid];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([localTargetMock verify], @"Should have received action.");
 
@@ -514,7 +514,7 @@
                        @"Should have thrown an exception because the target dropped out of scope.");
     }] testOne];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
 }
 
@@ -536,7 +536,7 @@
     // note: this causes the mock to expect the invocation of the selector, not that of performSelector:
     [[_targetMock expect] performSelector:@selector(actionName)];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should have received action.");
 #undef actionName
@@ -561,7 +561,7 @@
     // note: this causes the mock to expect the invocation of the selector, not that of performSelector:withObject:
     [[_targetMock expect] performSelector:@selector(actionName) withObject:actionArg];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should have received action.");
 #undef actionName
@@ -588,7 +588,7 @@
     // note: this causes the mock to expect the invocation of the selector, not that of performSelector:
     [[[_targetMock expect] andReturn:@(expectedReturnValue)] performSelector:@selector(actionName)];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should have received action.");
 #undef actionName
@@ -616,7 +616,7 @@
     // note: this causes the mock to expect the invocation of the selector, not that of performSelector:
     [[[_targetMock expect] andReturn:@(expectedReturnValue)] performSelector:@selector(actionName) withObject:actionArg];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:_testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:_testClass], nil);
     STAssertNoThrow([_testMock verify], @"Should have executed test.");
     STAssertNoThrow([_targetMock verify], @"Target should have received action.");
 #undef actionName

--- a/Unit Tests/SLTestControllerTests.m
+++ b/Unit Tests/SLTestControllerTests.m
@@ -68,7 +68,7 @@
                                         failed:[OCMArg anyPointer]
                             failedUnexpectedly:[OCMArg anyPointer]];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:abstractTestClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:abstractTestClass], nil);
     STAssertNoThrow([testMock verify], @"Test was run despite not having any test cases.");
 }
 
@@ -91,7 +91,7 @@
                                                                     failed:[OCMArg anyPointer]
                                                         failedUnexpectedly:[OCMArg anyPointer]];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObjects:testSupportingCurrentPlatformClass, testNotSupportingCurrentPlatformClass, nil], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObjects:testSupportingCurrentPlatformClass, testNotSupportingCurrentPlatformClass, nil], nil);
     STAssertNoThrow([testSupportingCurrentPlatformMock verify], @"Test supporting current platform was not run as expected.");
     STAssertNoThrow([testNotSupportingCurrentPlatformMock verify], @"Test not supporting current platform was unexpectedly run.");
 }
@@ -105,7 +105,7 @@
     Class testWithSomeFocusedTestCasesClass = [TestWithSomeFocusedTestCases class];
     STAssertTrue([testWithSomeFocusedTestCasesClass isFocused],
                  @"For the purposes of this test, this SLTest must be focused.");
-    NSSet *tests = [NSSet setWithObjects:
+    NSArray *tests = [NSArray arrayWithObjects:
         testThatIsNotFocusedClass,
         testWithSomeFocusedTestCasesClass,
         nil
@@ -128,7 +128,7 @@
 }
 
 - (void)testThatMultipleTestsCanBeFocusedAndRun {
-    NSSet *tests = [NSSet setWithObjects:
+    NSArray *tests = [NSArray arrayWithObjects:
         [TestThatIsNotFocused class],
         [TestWithSomeFocusedTestCases class],
         [Focus_TestThatIsFocused class],
@@ -177,7 +177,7 @@
     STAssertFalse([testThatIsFocusedButDoesntSupportCurrentPlatformClass supportsCurrentPlatform],
                   @"For the purposes of this test, this SLTest must not support current platform.");
 
-    NSSet *tests = [NSSet setWithObjects:
+    NSArray *tests = [NSArray arrayWithObjects:
         testThatIsNotFocusedClass,
         testThatIsFocusedButDoesntSupportCurrentPlatformClass,
         nil
@@ -210,7 +210,7 @@
                  @"For the purposes of this test, this SLTest must be focused.");
 
     // The test controller won't be told to run the focused test, thus it won't be run...
-    NSSet *testsToRun = [NSSet setWithObject:testWithSomeTestCasesClass];
+    NSArray *testsToRun = [NSArray arrayWithObject:testWithSomeTestCasesClass];
 
     id testWithSomeFocusedTestCasesClassMock = [OCMockObject partialMockForClass:testWithSomeFocusedTestCasesClass];
     [[testWithSomeFocusedTestCasesClassMock reject] runAndReportNumExecuted:[OCMArg anyPointer]
@@ -249,7 +249,7 @@
     // warning at end
     [[_loggerMock expect] logWarning:@"This was a focused run. Fewer test cases may have run than normal."];
     
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([sequencer verify], @"Test was not run/messages were not logged as expected.");
 }
 

--- a/Unit Tests/SLTestTests.m
+++ b/Unit Tests/SLTestTests.m
@@ -59,8 +59,8 @@
 #pragma mark - Test lookup
 
 - (void)testAllTestsReturnsExpected {
-    NSSet *allTests = [SLTest allTests];
-    NSSet *expectedTests = [NSSet setWithObjects:
+    NSSet *allTestsSet = [NSSet setWithArray:[SLTest allTests]];
+    NSSet *expectedTestsSet = [NSSet setWithArray:[NSArray arrayWithObjects:
         [SLTest class],
         [TestWithSomeTestCases class],
         [AbstractTest class],
@@ -80,6 +80,33 @@
         [Focus_TestThatIsFocusedButDoesntSupportCurrentPlatform class],
         [Focus_AbstractTestThatIsFocused class],
         [ConcreteTestThatIsFocused class],
+        nil
+    ]];
+    STAssertEqualObjects(allTestsSet, expectedTestsSet, @"Unexpected tests returned.");
+}
+
+- (void)testAllTestsReturnsInAlphaNumericOrder {
+    NSArray *allTests = [SLTest allTests];
+    NSArray *expectedTests = [NSArray arrayWithObjects:
+        [AbstractTest class],
+        [AbstractTestWhichSupportsOnly_iPad class],
+        [ConcreteTestThatIsFocused class],
+        [ConcreteTestWhichSupportsOnlyiPad class],
+        [Focus_AbstractTestThatIsFocused class],
+        [Focus_TestThatIsFocused class],
+        [Focus_TestThatIsFocusedButDoesntSupportCurrentPlatform class],
+        [Focus_TestWhereNarrowestFocusApplies class],
+        [SLTest class],
+        [TestNotSupportingCurrentPlatform class],
+        [TestThatIsNotFocused class],
+        [TestWhichSupportsAllPlatforms class],
+        [TestWhichSupportsOnlyiPad_iPad class],
+        [TestWhichSupportsOnlyiPhone_iPhone class],
+        [TestWithAFocusedPlatformSpecificTestCase class],
+        [TestWithAFocusedTestCase class],
+        [TestWithPlatformSpecificTestCases class],
+        [TestWithSomeFocusedTestCases class],
+        [TestWithSomeTestCases class],
         nil
     ];
     STAssertEqualObjects(allTests, expectedTests, @"Unexpected tests returned.");
@@ -200,7 +227,7 @@
     [[testMock reject] performSelector:unsupportedTestCaseSelector];
 #pragma clang diagnostic pop
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testWithPlatformSpecificTestCasesTest], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testWithPlatformSpecificTestCasesTest], nil);
     STAssertNoThrow([testMock verify], @"Test cases did not run as expected.");
 }
 
@@ -221,7 +248,7 @@
     [[testNotSupportingCurrentPlatformClassMock reject] performSelector:supportedTestCaseSelector];
 #pragma clang diagnostic pop
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testNotSupportingCurrentPlatformClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testNotSupportingCurrentPlatformClass], nil);
     STAssertNoThrow([testNotSupportingCurrentPlatformClassMock verify],
                     @"Test case supporting current platform was run despite its test not supporting the current platform.");
 }
@@ -308,7 +335,7 @@
     [[testWithAFocusedTestCaseClassMock reject] testOne];
     [[testWithAFocusedTestCaseClassMock expect] focus_testTwo];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testWithAFocusedTestCaseClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testWithAFocusedTestCaseClass], nil);
     STAssertNoThrow([testWithAFocusedTestCaseClassMock verify], @"Test cases did not execute as expected.");
 }
 
@@ -321,7 +348,7 @@
     [[testWithSomeFocusedTestCasesClassMock expect] focus_testTwo];
     [[testWithSomeFocusedTestCasesClassMock expect] focus_testThree];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testWithSomeFocusedTestCasesClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testWithSomeFocusedTestCasesClass], nil);
     STAssertNoThrow([testWithSomeFocusedTestCasesClassMock verify], @"Test cases did not execute as expected.");
 }
 
@@ -335,7 +362,7 @@
     id testThatIsFocusedClassMock = [OCMockObject partialMockForClass:testThatIsFocusedClass];
     [[testThatIsFocusedClassMock expect] testFoo];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testThatIsFocusedClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testThatIsFocusedClass], nil);
     STAssertNoThrow([testThatIsFocusedClassMock verify], @"Test cases did not execute as expected.");
 }
 
@@ -350,7 +377,7 @@
     [[testWhereNarrowestFocusAppliesClassMock reject] testOne];
     [[testWhereNarrowestFocusAppliesClassMock expect] focus_testTwo];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testWhereNarrowestFocusAppliesClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testWhereNarrowestFocusAppliesClass], nil);
     STAssertNoThrow([testWhereNarrowestFocusAppliesClassMock verify], @"Test cases did not execute as expected.");
 }
 
@@ -370,7 +397,7 @@
     [[testWithAFocusedTestCaseClassMock expect] setUpTestCaseWithSelector:@selector(testTwo)];
     [[testWithAFocusedTestCaseClassMock expect] tearDownTestCaseWithSelector:@selector(testTwo)];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testWithAFocusedTestCaseClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testWithAFocusedTestCaseClass], nil);
     STAssertNoThrow([testWithAFocusedTestCaseClassObjectMock verify], @"Test cases did not execute as expected.");
     STAssertNoThrow([testWithAFocusedTestCaseClassMock verify], @"Test cases did not execute as expected.");
 }
@@ -389,7 +416,7 @@
     [[testWithAFocusedPlatformSpecificTestCaseClassMock reject] focus_testBar_iPad];
     [[testWithAFocusedPlatformSpecificTestCaseClassMock expect] testFoo];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testWithAFocusedPlatformSpecificTestCaseClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testWithAFocusedPlatformSpecificTestCaseClass], nil);
     STAssertNoThrow([testWithAFocusedPlatformSpecificTestCaseClassMock verify], @"Test cases did not execute as expected.");
 }
 
@@ -405,7 +432,7 @@
     [[testMock expect] testTwo];
     [[testMock expect] testThree];
     
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testWithSomeTestCasesTest], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testWithSomeTestCasesTest], nil);
     STAssertNoThrow([testMock verify], @"Test cases did not run as expected.");
 }
 
@@ -420,7 +447,7 @@
     [[testMock reject] testThatIsntATestBecauseItsReturnTypeIsNonVoid];
     [[testMock reject] testThatIsntATestBecauseItTakesAnArgument:OCMOCK_ANY];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testWithSomeTestCasesTest], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testWithSomeTestCasesTest], nil);
     STAssertNoThrow([testMock verify], @"Invalid test cases were unexpectedly run.");
 }
 
@@ -465,7 +492,7 @@
     // *** End expected test run
     
     // Run tests and verify
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testSequencer verify], @"Testing did not execute in the expected sequence.");
 }
 
@@ -491,7 +518,7 @@
     // *** End expected test run
 
     // Run tests and verify
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"-setUpTest and -tearDownTest did not execute once, at the start and end of the test.");
 }
 
@@ -526,7 +553,7 @@
         // *** End expected test run
 
         // Run tests and verify
-        SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+        SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
         STAssertNoThrow([testMock verify], @"-setUpTestCaseWithSelector: and -tearDownTestCaseWithSelector: did not execute once before and after each test case.");
     }
 }
@@ -563,7 +590,7 @@
 
     // *** End expected test run
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:failingTestClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:failingTestClass], nil);
     STAssertNoThrow([failingTestSequencer verify], @"Test did not fail/messages were not logged in the expected sequence.");
 }
 
@@ -604,7 +631,7 @@
 
     // *** End expected test run
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObjects:failingTestClass, otherTestClass, nil], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObjects:failingTestClass, otherTestClass, nil], nil);
     STAssertNoThrow([failingTestMock verify], @"Failing test did not run.");
     STAssertNoThrow([otherTestMock verify], @"Other test did not run.");
 }
@@ -630,7 +657,7 @@
     // we expect teardown to still execute
     [[failingTestMock expect] tearDownTest];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObjects:failingTestClass, nil], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObjects:failingTestClass, nil], nil);
     STAssertNoThrow([failingTestMock verify], @"Test did not run as expected.");
 }
 
@@ -647,7 +674,7 @@
     // none of the test cases should have executed
     [[failingTestMock reject] setUpTestCaseWithSelector:[OCMArg anySelector]];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObjects:failingTestClass, nil], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObjects:failingTestClass, nil], nil);
     STAssertNoThrow([failingTestMock verify], @"Test did not run as expected.");
 }
 
@@ -689,7 +716,7 @@
 
     // *** End expected test run
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:failingTestClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:failingTestClass], nil);
     STAssertNoThrow([failingTestSequencer verify], @"Test did not run/messages were not logged in the expected sequence.");
 }
 
@@ -719,7 +746,7 @@
 
     // *** End expected test run
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:failingTestClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:failingTestClass], nil);
     STAssertNoThrow([failingTestMock verify], @"Test did not run as expected.");
 }
 
@@ -741,7 +768,7 @@
 
     // *** End expected test run
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:failingTestClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:failingTestClass], nil);
     STAssertNoThrow([failingTestMock verify], @"Test did not run as expected.");
 }
 
@@ -772,7 +799,7 @@
 
     // *** End expected test run
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:failingTestClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:failingTestClass], nil);
     STAssertNoThrow([failingTestMock verify], @"Test did not run as expected.");
 }
 
@@ -810,7 +837,7 @@
 
     // *** End expected test run
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([failingTestSequencer verify], @"Test did not run/messages were not logged in the expected sequence.");
 }
 
@@ -855,7 +882,7 @@
 
     // *** End expected test run
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:failingTestClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:failingTestClass], nil);
     STAssertNoThrow([failingTestSequencer verify], @"Test did not fail/messages were not logged in the expected sequence.");
 }
 
@@ -885,7 +912,7 @@
 
     // *** End expected test run
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:failingTestClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:failingTestClass], nil);
     STAssertNoThrow([failingTestMock verify], @"Test did not run as expected.");
 }
 
@@ -907,7 +934,7 @@
 
     // *** End expected test run
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:failingTestClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:failingTestClass], nil);
     STAssertNoThrow([failingTestMock verify], @"Test did not run as expected.");
 }
 
@@ -946,7 +973,7 @@
         return [errorMessage hasPrefix:filenameAndLineNumberPrefix];
     }]];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([sequencer verify], @"Test did not run/message was not logged in expected sequence.");
 }
 
@@ -972,7 +999,7 @@
         }], @"Assertion should have failed.");
     }] testTwo];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test case did not execute as expected.");
 }
 
@@ -990,7 +1017,7 @@
         }], @"Assertion should not have failed.");
     }] testOne];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test case did not execute as expected.");
 }
 
@@ -1016,7 +1043,7 @@
         }], @"Assertion should have failed.");
     }] testTwo];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test case did not execute as expected.");
 }
 
@@ -1039,7 +1066,7 @@
         STAssertEqualsWithAccuracy(endTimeInterval, startTimeInterval, .01, @"Test should not have waited for an appreciable interval.");
     }] testOne];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test case did not execute as expected.");
 }
 
@@ -1067,7 +1094,7 @@
                                    @"Test should have only waited for about the amount of time necessary for the condition to become true.");
     }] testThree];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test case did not execute as expected.");
 }
 
@@ -1090,7 +1117,7 @@
                                    @"Test should have waited for the specified timeout.");
     }] testTwo];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test case did not execute as expected.");
 }
 
@@ -1116,7 +1143,7 @@
         STAssertEqualsWithAccuracy(endTimeInterval, startTimeInterval, .01, @"Test should not have waited for an appreciable interval.");
     }] testOne];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test case did not execute as expected.");
 }
 
@@ -1147,7 +1174,7 @@
                                    @"Test should have only waited for about the amount of time necessary for the condition to become true.");
     }] testThree];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test case did not execute as expected.");
 }
 
@@ -1173,7 +1200,7 @@
                                    @"Test should have waited for the specified timeout.");
     }] testTwo];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test case did not execute as expected.");
 }
 
@@ -1197,7 +1224,7 @@
         STAssertThrows([test slAssertThrows:^{}], @"Assertion should have failed.");
     }] testTwo];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test cases did not execute as expected.");
 }
 
@@ -1215,7 +1242,7 @@
         STAssertThrows([test slAssertThrows:^{} named:@"TestException"], @"Assertion should have failed.");
     }] testTwo];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test case did not execute as expected.");
 }
 
@@ -1241,7 +1268,7 @@
         } named:exceptionName], @"Assertion should have failed.");
     }] testTwo];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test cases did not execute as expected.");
 }
 
@@ -1265,7 +1292,7 @@
         }], @"Assertion should have failed.");
     }] testTwo];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test case did not execute as expected.");
 }
 
@@ -1288,14 +1315,14 @@
                                    @"Test did not delay for expected interval.");
     }] testOne];
 
-    SLRunTestsAndWaitUntilFinished([NSSet setWithObject:testClass], nil);
+    SLRunTestsAndWaitUntilFinished([NSArray arrayWithObject:testClass], nil);
     STAssertNoThrow([testMock verify], @"Test case was not executed as expected.");
 }
 
 #pragma mark - Internal
 
 - (void)testTestCasesAreDiscoveredAsExpected {
-    NSSet *testCases = [NSSet setWithObjects:@"testOne", @"testTwo", @"testThree", nil];
+    NSSet *testCases = [NSSet setWithArray:[NSArray arrayWithObjects:@"testOne", @"testTwo", @"testThree", nil]];
     STAssertEqualObjects(testCases, [TestWithSomeTestCases testCases],
                          @"Test cases were not discovered as expected.");
 }

--- a/Unit Tests/TestUtilities.h
+++ b/Unit Tests/TestUtilities.h
@@ -15,7 +15,7 @@
  @param tests The SLTest classes to run.
  @param completionBlock The optional completion block to execute after testing finishes.
  */
-extern void SLRunTestsAndWaitUntilFinished(NSSet *tests, void (^completionBlock)());
+extern void SLRunTestsAndWaitUntilFinished(NSArray *tests, void (^completionBlock)());
 
 
 /**

--- a/Unit Tests/TestUtilities.m
+++ b/Unit Tests/TestUtilities.m
@@ -8,7 +8,7 @@
 
 #import "TestUtilities.h"
 
-void SLRunTestsAndWaitUntilFinished(NSSet *tests, void (^completionBlock)()) {
+void SLRunTestsAndWaitUntilFinished(NSArray *tests, void (^completionBlock)()) {
     __block BOOL testingHasFinished = NO;
     [[SLTestController sharedTestController] runTests:tests
                                   withCompletionBlock:^{


### PR DESCRIPTION
We have a few tests that need to be executed in a specific order at app launch, so I've switched use of sets to ordered arrays.

I'm happy to approach this differently if it's a feature you have any interest in merging.
