### PR TITLE
Fix error checking around instruments failing to launch.

### DIFF
--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -500,8 +500,8 @@ launch_instruments () {
 		-e UIARESULTSPATH "$RESULTS_DIR"
 }
 
-launch_instruments
 RESULT_LOG="$RESULTS_DIR/Run 1/Automation Results.plist"
+launch_instruments
 if [ $? -ne 0 ] && [ ! -e "$RESULT_LOG" ]; then
 	# Under poorly understood circumstances, in certain CI environments like Travis, 
 	# instruments may fail to launch what otherwise appears to be a perfectly good app 


### PR DESCRIPTION
By assigning to `RESULT_LOG` after launching instruments,
we failed to check instruments' exit status.
