### PR TITLE
Elements rename JavaScript exceptions occurring during action-sends. (fi...

### DIFF
--- a/Integration Tests/Tests/SLElementTapTest.m
+++ b/Integration Tests/Tests/SLElementTapTest.m
@@ -73,7 +73,7 @@
         // If we had disallowed the tap on the basis of UIAutomation saying that
         // the scroll view was not tappable, we would have thrown an SLElementNotTappableException.
         SLAssertThrowsNamed([UIAElement(scrollView) tap],
-                            SLTerminalJavaScriptException,
+                            SLUIAElementAutomationException,
                             @"Should have allowed tap, but not have been able to tap element.");
         // sanity check
         SLAssertTrue(SLAskApp(tapPoint) == nil, @"Scroll view should not have been tapped.");
@@ -161,7 +161,7 @@
                                                    thenPerformActionWithUIARepresentation:^(NSString *UIARepresentation) {
                             [[SLTerminal sharedTerminal] evalWithFormat:@"%@.tap()", UIARepresentation];
                         } timeout:[SLElement defaultTimeout]]),
-                        SLTerminalJavaScriptException,
+                        SLUIAElementAutomationException,
                         @"Element should not have been able to be tapped.");
     NSTimeInterval endTimeInterval = [NSDate timeIntervalSinceReferenceDate];
     NSTimeInterval waitTimeInterval = endTimeInterval - startTimeInterval;

--- a/Integration Tests/Tests/SLStaticElementTest.m
+++ b/Integration Tests/Tests/SLStaticElementTest.m
@@ -219,7 +219,7 @@
                                   thenPerformActionWithUIARepresentation:^(NSString *UIARepresentation) {
                                       [[SLTerminal sharedTerminal] evalWithFormat:@"%@.tap()", UIARepresentation];
                                   } timeout:[SLStaticElement defaultTimeout]]),
-                            SLTerminalJavaScriptException,
+                            SLUIAElementAutomationException,
                             @"Should have tried to tap the scroll view and found it to not be tappable.");
     } else {
         SLAssertNoThrow(([UIAElement(scrollView) waitUntilTappable:YES

--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -607,6 +607,12 @@ extern NSString *const SLTestExceptionFilenameKey;
 /// which the exception occurred.
 extern NSString *const SLTestExceptionLineNumberKey;
 
+/// Prefixes logs of exceptions, caught by the tests, for which call site information could not be determined:
+/// exceptions thrown in contexts other than failures in assertions or `SLUIAElement` methods.
+/// For `SLUIAElement` exceptions to be tagged with call site information, test writers must wrap
+/// elements in the `UIAElement` macro. See that macro's documentation for an example.
+extern NSString *const SLTestUnknownCallSite;
+
 /// The interval for which `SLAssertTrueWithTimeout` and `SLWaitUntilTrue`
 /// wait before re-evaluating their conditions.
 extern const NSTimeInterval SLWaitUntilTrueRetryDelay;

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -39,6 +39,8 @@ NSString *const SLTestAssertionFailedException  = @"SLTestCaseAssertionFailedExc
 NSString *const SLTestExceptionFilenameKey      = @"SLTestExceptionFilenameKey";
 NSString *const SLTestExceptionLineNumberKey    = @"SLTestExceptionLineNumberKey";
 
+NSString *const SLTestUnknownCallSite           = @"Unknown location";
+
 const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
 
 
@@ -379,7 +381,7 @@ const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
          [[exception name] hasPrefix:SLUIAElementExceptionNamePrefix])) {
         callSite = [NSString stringWithFormat:@"%@:%d", _lastKnownFilename, _lastKnownLineNumber];
     } else {
-        callSite = @"Unknown location";
+        callSite = SLTestUnknownCallSite;
     }
     // the call site info is definitely stale at this point
     [self clearLastKnownCallSite];

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -360,12 +360,14 @@ const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
 }
 
 - (void)logException:(NSException *)exception inTestCase:(NSString *)testCase asExpected:(BOOL)expected {
-    // Only use the call site information if the exception was thrown by `SLTest` or `SLUIAElement`,
+    // Only use the call site information if we have information
+    // and if the exception was thrown by `SLTest` or `SLUIAElement`,
     // where the information was likely to have been recorded by an assertion or UIAElement macro.
     // Otherwise it is likely stale.
     NSString *callSite;
-    if ([[exception name] hasPrefix:SLTestExceptionNamePrefix] ||
-        [[exception name] hasPrefix:SLUIAElementExceptionNamePrefix]) {
+    if (_lastKnownFilename &&
+        ([[exception name] hasPrefix:SLTestExceptionNamePrefix] ||
+         [[exception name] hasPrefix:SLUIAElementExceptionNamePrefix])) {
         callSite = [NSString stringWithFormat:@"%@:%d", _lastKnownFilename, _lastKnownLineNumber];
     } else {
         callSite = @"Unknown location";

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -360,7 +360,7 @@ const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
 }
 
 - (void)logException:(NSException *)exception inTestCase:(NSString *)testCase asExpected:(BOOL)expected {
-    // Only use the call site information if the exception was thrown by SLTest or SLElement,
+    // Only use the call site information if the exception was thrown by `SLTest` or `SLUIAElement`,
     // where the information was likely to have been recorded by an assertion or UIAElement macro.
     // Otherwise it is likely stale.
     NSString *callSite;

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLElement.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLElement.m
@@ -210,7 +210,13 @@ UIAccessibilityTraits SLUIAccessibilityTraitAny = 0;
             block(UIARepresentation);
         }
         @catch (NSException *exception) {
-            actionException = exception;
+            // rename JavaScript exceptions to make the context of the exception clear
+            if ([[exception name] isEqualToString:SLTerminalJavaScriptException]) {
+                actionException = [NSException exceptionWithName:SLUIAElementAutomationException
+                                                          reason:[exception reason] userInfo:[exception userInfo]];
+            } else {
+                actionException = exception;
+            }
         }
     }];
     if (actionException) @throw actionException;

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLStaticElement.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLStaticElement.m
@@ -74,7 +74,17 @@
         }
     }
 
-    block(_UIARepresentation);
+    @try {
+        block(_UIARepresentation);
+    }
+    @catch (NSException *exception) {
+        // rename JavaScript exceptions to make the context of the exception clear
+        if ([[exception name] isEqualToString:SLTerminalJavaScriptException]) {
+            exception = [NSException exceptionWithName:SLUIAElementAutomationException
+                                                reason:[exception reason] userInfo:[exception userInfo]];
+        }
+        @throw exception;
+    }
 }
 
 - (BOOL)isValid {

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLUIAElement.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLUIAElement.h
@@ -381,12 +381,15 @@
 /// All exceptions thrown by SLUIAElement will have names beginning with this prefix.
 extern NSString *const SLUIAElementExceptionNamePrefix;
 
-/// Thrown if an element is messaged which it is [invalid](-isValid).
+/// Thrown if an element is messaged while it is [invalid](-isValid).
 extern NSString *const SLUIAElementInvalidException;
 
 /// Thrown if tests attempt to simulate user interaction with an element
 /// while that element is not [tappable](-isTappable).
 extern NSString *const SLUIAElementNotTappableException;
+
+/// Thrown if the Automation instrument is unable to interpret a command from the tests.
+extern NSString *const SLUIAElementAutomationException;
 
 /// `SLUIAElement` waits for this duration between checks of an element's
 /// validity, tappability, etc.

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLUIAElement.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLUIAElement.m
@@ -27,11 +27,12 @@
 
 
 // all exceptions thrown by SLUIAElement must have names beginning with this prefix
-// so that -[SLTest logException:inTestCase:] uses the proper logging format
+// so that `-[SLTest logException:inTestCase:asExpected:]` uses the proper logging format
 NSString *const SLUIAElementExceptionNamePrefix    = @"SLUIAElement";
 
 NSString *const SLUIAElementInvalidException       = @"SLUIAElementInvalidException";
 NSString *const SLUIAElementNotTappableException   = @"SLUIAElementNotTappableException";
+NSString *const SLUIAElementAutomationException    = @"SLUIAElementAutomationException";
 
 const NSTimeInterval SLUIAElementWaitRetryDelay = 0.25;
 

--- a/Unit Tests/TestUtilities.h
+++ b/Unit Tests/TestUtilities.h
@@ -49,4 +49,8 @@ extern void SLRunTestsAndWaitUntilFinished(NSSet *tests, void (^completionBlock)
 - (void)slAssertThrows:(void (^)(void))expression named:(NSString *)exceptionName;
 - (void)slAssertNoThrow:(void (^)(void))expression;
 
+- (void)slFailWithExceptionRecordedByUIAElementMacro:(NSException *)exception
+                                thrownBySLUIAElement:(BOOL)haveSLUIAElementThrow
+                                          atFilename:(NSString *__autoreleasing *)filename lineNumber:(int *)lineNumber;
+
 @end

--- a/Unit Tests/TestUtilities.m
+++ b/Unit Tests/TestUtilities.m
@@ -7,6 +7,7 @@
 //
 
 #import "TestUtilities.h"
+#import <OCMock/OCMock.h>
 
 void SLRunTestsAndWaitUntilFinished(NSSet *tests, void (^completionBlock)()) {
     __block BOOL testingHasFinished = NO;
@@ -86,6 +87,28 @@ void SLRunTestsAndWaitUntilFinished(NSSet *tests, void (^completionBlock)()) {
 - (void)slAssertNoThrow:(void (^)(void))expression {
     NSParameterAssert(expression);
     SLAssertNoThrow(expression(), nil);
+}
+
+- (void)slFailWithExceptionRecordedByUIAElementMacro:(NSException *)exception
+                                thrownBySLUIAElement:(BOOL)haveSLUIAElementThrow
+                                          atFilename:(NSString *__autoreleasing *)filename lineNumber:(int *)lineNumber {
+    NSParameterAssert(exception);
+    NSParameterAssert(filename);
+    NSParameterAssert(lineNumber);
+
+    // create a fake element to tap, optionally throwing the exception with which this test case should fail
+    id mockElement = [OCMockObject niceMockForClass:[SLUIAElement class]];
+    if (haveSLUIAElementThrow) {
+        [[[mockElement stub] andThrow:exception] tap];
+    }
+
+    // purposefully put everything below on one line
+    // so that we return by-reference the same filename and line number that `UIAElement` records
+    *filename = [@(__FILE__) lastPathComponent]; *lineNumber = __LINE__; [UIAElement(mockElement) tap];
+
+    NSAssert(!haveSLUIAElementThrow,
+             @"If `haveSLUIAElementThrow` was `YES`, this method should have already thrown an exception.");
+    [exception raise];
 }
 
 @end


### PR DESCRIPTION
...xes #63)

So that `SLTest` will attach call-site information recorded by the `UIAElement`
macro to those exceptions.
