### PR TITLE
`SLAlertHandler` now optionally logs alerts as they are handled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: objective-c
 
 # These tasks run before cd'ing into Subliminal's repo
 before_install:
-    - brew update
+# Install required tools
+# - `xctool`, required to build the unit test and documentation targets
+# 	nothing to do here because it's already installed on Travis
 
-# `xctool` is required to build the unit test and documentation targets
-# but it is already installed on Travis
+# - `appledoc`, used to build documentation
+# 	Force the usage of appledoc 2.1 until https://github.com/inkling/Subliminal/issues/71 is addressed
+    - brew install https://raw.github.com/mxcl/homebrew/33aa810/Library/Formula/appledoc.rb
 
-# Used to build documentation
-    - brew install appledoc
 # Initialize test dependencies (OCMock)
     - git submodule update --init --recursive
 

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.h
@@ -289,6 +289,7 @@ extern const NSTimeInterval SLAlertHandlerDidHandleAlertDelay;
  */
 @interface SLAlert (Debugging)
 
+#pragma mark - Debugging Tests
 /// -------------------------------------------
 /// @name Debugging Tests
 /// -------------------------------------------
@@ -307,6 +308,41 @@ extern const NSTimeInterval SLAlertHandlerDidHandleAlertDelay;
 @end
 
 #endif
+
+/**
+ The methods in the `SLAlertHandler (Debugging)` category may be useful 
+ in debugging Subliminal tests.
+ */
+@interface SLAlertHandler (Debugging)
+
+#pragma mark - Debugging Tests
+/// ------------------------------------------
+/// @name Debugging Tests
+/// ------------------------------------------
+
+/**
+ Enables or disables alert-handling logging.
+ 
+ If logging is enabled, Subliminal will log alerts as they are handled
+ (by handlers registered by tests or by Subliminal's default handler).
+ 
+ Logging is disabled by default.
+ 
+ @param enableLogging   If `YES`, alert-handling logging is enabled; 
+                        otherwise, alert-handling logging is disabled.
+ */
++ (void)setLoggingEnabled:(BOOL)enableLogging;
+
+/**
+ Returns `YES` if Subliminal should log alerts as they are handled.
+
+ @return `YES` if alert-handling logging is enabled, `NO` otherwise.
+
+ @see -setLoggingEnabled:
+ */
++ (BOOL)loggingEnabled;
+
+@end
 
 
 /**


### PR DESCRIPTION
Allowing tests to observe and debug alert handling,
especially the automatic handling of unexpected alerts.
