### PR TITLE
Subliminal reloads the accessibility hierarchy as necessary while matching.

### DIFF
--- a/Integration Tests/Tests/SLElementMatchingTest.m
+++ b/Integration Tests/Tests/SLElementMatchingTest.m
@@ -402,4 +402,13 @@
                  @"After being matched, an object's identifier should have been restored.");
 }
 
+- (void)testSubliminalReloadsTheAccessibilityHierarchyAsNecessaryWhenMatching {
+    SLElement *fooLabel = [SLElement elementWithAccessibilityLabel:@"foo"];
+    SLAssertTrue([[UIAElement(fooLabel) label] isEqualToString:@"foo"], @"Could not match label.");
+
+    SLAskApp(invalidateAccessibilityHierarchy);
+
+    SLAssertTrue([[UIAElement(fooLabel) label] isEqualToString:@"foo"], @"Could not match label.");
+}
+
 @end

--- a/Integration Tests/Tests/SLElementMatchingTestViewController.m
+++ b/Integration Tests/Tests/SLElementMatchingTestViewController.m
@@ -29,6 +29,8 @@
 @end
 
 
+#pragma mark - SLElementMatchingTestCell
+
 @interface SLElementMatchingTestCell : UITableViewCell
 
 - (void)configureAccessibility;
@@ -58,7 +60,7 @@
             _weatherTemp.textAlignment = NSTextAlignmentRight;
             [self.contentView addSubview:_weatherTemp];
         } else {
-            NSAssert(NO, @"%@ reuse identifier was not of expected format: '%@_<%@ test case>'.",
+            NSAssert(NO, @"%@ reuse identifier was not of expected format ('%@_<%@ test case>') or was unexpected.",
                      NSStringFromClass([self class]), NSStringFromClass([self class]), NSStringFromClass([SLElementMatchingTestViewController class]));
         }
     }
@@ -104,6 +106,55 @@
 
 @end
 
+
+#pragma mark - SLElementMatchingTestHeader
+
+@interface SLElementMatchingTestHeader : UIView
+
+- (instancetype)initWithTestCaseWithSelector:(SEL)testCase;
+
+@end
+
+@implementation SLElementMatchingTestHeader {
+    UIView *_leftView, *_rightView;
+}
+
+- (instancetype)initWithTestCaseWithSelector:(SEL)testCase {
+    self = [super initWithFrame:CGRectZero];
+    if (self) {
+        if (testCase == @selector(testMatchingTableViewHeaderChildElements)) {
+            UILabel *leftLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+            leftLabel.textAlignment = NSTextAlignmentLeft;
+            leftLabel.text = @"left";
+            _leftView = leftLabel;
+
+            UILabel *rightLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+            rightLabel.textAlignment = NSTextAlignmentRight;
+            rightLabel.text = @"right";
+            _rightView = rightLabel;
+        } else {
+            NSAssert(NO, @"Unexpected test case: %@", NSStringFromSelector(testCase));
+        }
+        [self addSubview:_leftView];
+        [self addSubview:_rightView];
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+
+    CGRect contentRect = CGRectInset(self.bounds, 20.0f, 0.0f);
+    CGRect leftViewFrame, rightViewFrame;
+    CGRectDivide(contentRect, &leftViewFrame, &rightViewFrame, CGRectGetWidth(contentRect) / 2.0f, CGRectMinXEdge);
+    _leftView.frame = leftViewFrame;
+    _rightView.frame = rightViewFrame;
+}
+
+@end
+
+
+#pragma mark - SLElementMatchingTestViewController
 
 @interface SLElementMatchingTestViewController () <UITableViewDataSource, UITableViewDelegate, UIWebViewDelegate>
 
@@ -289,31 +340,7 @@
         [label sizeToFit];
         headerView = label;
     } else if (self.testCase == @selector(testMatchingTableViewHeaderChildElements)) {
-        CGFloat headerHeight = [self tableView:tableView heightForHeaderInSection:section];
-        CGRect headerRect = (CGRect){
-            CGPointZero,
-            CGSizeMake(CGRectGetWidth(tableView.frame), headerHeight)
-        };
-        headerView = [[UIView alloc] initWithFrame:headerRect];
-        CGRect contentRect = CGRectInset(headerRect, 20.0f, 0.0f);
-        CGFloat halfWidth = CGRectGetWidth(contentRect) / 2.0;
-        CGSize halfSize = CGSizeMake(halfWidth, CGRectGetHeight(contentRect));
-
-        UILabel *labelLeft = [[UILabel alloc] initWithFrame:(CGRect){
-            contentRect.origin,
-            halfSize
-        }];
-        labelLeft.textAlignment = NSTextAlignmentLeft;
-        labelLeft.text = @"left";
-        [headerView addSubview:labelLeft];
-
-        UILabel *labelRight = [[UILabel alloc] initWithFrame:(CGRect){
-            CGPointMake(CGRectGetMinX(contentRect) + halfWidth, CGRectGetMinY(contentRect)),
-            halfSize
-        }];
-        labelRight.textAlignment = NSTextAlignmentRight;
-        labelRight.text = @"right";
-        [headerView addSubview:labelRight];
+        headerView = [[SLElementMatchingTestHeader alloc] initWithTestCaseWithSelector:self.testCase];
     }
 
     return headerView;

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.h
@@ -336,6 +336,8 @@ extern const NSTimeInterval SLAlertHandlerDidHandleAlertDelay;
 /**
  Returns `YES` if Subliminal should log alerts as they are handled.
 
+ Logging is disabled by default.
+
  @return `YES` if alert-handling logging is enabled, `NO` otherwise.
 
  @see -setLoggingEnabled:

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLElement.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLElement.h
@@ -174,3 +174,28 @@
 /// Used with `+[SLElement elementWithAccessibilityLabel:value:traits:]`
 /// to match elements with any combination of accessibility traits.
 extern UIAccessibilityTraits SLUIAccessibilityTraitAny;
+
+
+#pragma mark - Debugging Subliminal
+
+/**
+ The methods in the `SLElement (DebugSettings)` category may be useful in debugging Subliminal.
+ */
+@interface SLElement (DebugSettings)
+
+/**
+ Determines whether the specified element should use UIAutomation to confirm that it [is valid](-isValid)
+ after Subliminal has determined (to the best of its ability) that it is valid.
+ 
+ If Subliminal misidentifies an element to UIAutomation, UIAutomation will not necessarily raise 
+ an exception but instead may silently fail (e.g. it may return `null` from APIs like `UIAElement.hitpoint()`, 
+ causing Subliminal to think that an element isn't tappable when really it's not valid). 
+ Enabling this setting may help in diagnosing such failures.
+ 
+ Validity double-checking is disabled (`NO`) by default, because it is more likely that there is a bug 
+ in a particular test than a bug in Subliminal, and because enabling double-checking will 
+ negatively affect the performance of the tests. 
+ */
+@property (nonatomic) BOOL shouldDoubleCheckValidity;
+
+@end


### PR DESCRIPTION
In certain circumstances, accessibility elements may become "stale", in that they match
views which are no longer in the hierarchy. When these elements are queried for their
accessibility information, their container will reload _all_ its child elements.
This could result in Subliminal finding a path to an element only to have the process
of finding that path invalidate the path! We now preemptively reload the accessibility
hierarchy while retrieving accessibility elements to ensure that accessibility paths remain
valid.
