### PR TITLE
Subliminal fully supports running tests on devices.

### DIFF
--- a/Supporting Files/CI/device-install.h
+++ b/Supporting Files/CI/device-install.h
@@ -1,0 +1,265 @@
+//
+//  device-install.h
+//  
+//	Copyright 2003 Inkling Systems, Inc.
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy 
+//	of this file and its contents (the "Header File"), to deal in the Header File 
+//	without restriction, including without limitation the rights to use, copy, 
+//	modify, merge, publish, distribute, sublicense, and/or sell copies of the 
+//	Header File, and to permit persons to whom the Header File is furnished to 
+//	do so, subject to the following conditions:
+//  
+//	The above copyright notice and this permission notice shall be included in 
+//	all copies or substantial portions of the Header File.
+//
+//	THE HEADER FILE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+//	OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+//	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+//	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+//	WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR 
+//	IN CONNECTION WITH THE HEADER FILE OR THE USE OR OTHER DEALINGS IN THE HEADER 
+//	FILE.
+//
+//
+//	This file is named `device-install.h` as it accompanies `device-install.m`, 
+//  but what it defines is an interface to `MobileDevice.framework`.
+//  This is by no means a complete interface, but only those structure definitions, 
+//	typedefs, and function prototypes necessary to `device-install.m`. More 
+//	information may be found online at http://theiphonewiki.com/wiki/MobileDevice_Library .
+//
+//	This file was produced with reference to several open-source projects.
+//  We credit those sources below but do not believe the licenses used for those 
+//	projects apply to this file, as this file does not rely on code from those 
+//	projects. Although we have used certain structure definitions, typedefs and 
+//	function prototypes from those projects, we do not believe that those elements 
+//	are copyrightable. However, as with anything publicly available, it is up to 
+//	you to determine whether the contents of this file and the licenses applicable 
+//	to it are suitable for your use.
+//
+
+
+// Unless otherwise noted, the structure definitions, typedefs and function prototypes 
+// below are reproduced from http://theiphonewiki.com/w/index.php?title=MobileDevice_Library&oldid=32928 .
+// Documentation is reproduced from http://theiphonewiki.com/w/index.php?title=MobileDevice_Library&oldid=30093 .
+//
+// Where definitions have diverged between http://theiphonewiki.com/w/index.php?title=MobileDevice_Library&oldid=30093
+// and http://theiphonewiki.com/w/index.php?title=MobileDevice_Library&oldid=32928 ,
+// the documentation from http://theiphonewiki.com/w/index.php?title=MobileDevice_Library&oldid=30093
+// has been updated by the author of this file (Inkling Systems, Inc.) to correspond 
+// to the definitions of http://theiphonewiki.com/w/index.php?title=MobileDevice_Library&oldid=32928 .
+#ifndef MOBILEDEVICE_H
+#define MOBILEDEVICE_H
+
+#ifndef __GNUC__
+#pragma pack
+#define __PACK
+#else
+#define __PACK __attribute__((__packed__))
+#endif
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <mach/error.h>
+
+	/* Error codes */
+#define MDERR_APPLE_MOBILE  (err_system(0x3a))
+#define MDERR_IPHONE        (err_sub(0))
+
+	/* Apple Mobile (AM*) errors */
+#define MDERR_OK                ERR_SUCCESS
+#define MDERR_SYSCALL           (ERR_MOBILE_DEVICE | 0x01)
+#define MDERR_OUT_OF_MEMORY     (ERR_MOBILE_DEVICE | 0x03)
+#define MDERR_QUERY_FAILED      (ERR_MOBILE_DEVICE | 0x04)
+#define MDERR_INVALID_ARGUMENT  (ERR_MOBILE_DEVICE | 0x0b)
+#define MDERR_DICT_NOT_LOADED   (ERR_MOBILE_DEVICE | 0x25)
+
+	/* Messages passed to device notification callbacks: passed as part of
+	 * AMDeviceNotificationCallbackInfo. */
+#define ADNCI_MSG_CONNECTED     1
+#define ADNCI_MSG_DISCONNECTED  2
+#define ADNCI_MSG_UNSUBSCRIBED  3
+
+#define AMD_IPHONE_PRODUCT_ID   0x1290
+	//#define AMD_IPHONE_SERIAL       ""
+
+	/* Services, found in /System/Library/Lockdown/Services.plist */
+#define AMSVC_AFC                   CFSTR("com.apple.afc")
+#define AMSVC_BACKUP                CFSTR("com.apple.mobilebackup")
+#define AMSVC_CRASH_REPORT_COPY     CFSTR("com.apple.crashreportcopy")
+#define AMSVC_DEBUG_IMAGE_MOUNT     CFSTR("com.apple.mobile.debug_image_mount")
+#define AMSVC_NOTIFICATION_PROXY    CFSTR("com.apple.mobile.notification_proxy")
+#define AMSVC_PURPLE_TEST           CFSTR("com.apple.purpletestr")
+#define AMSVC_SOFTWARE_UPDATE       CFSTR("com.apple.mobile.software_update")
+#define AMSVC_SYNC                  CFSTR("com.apple.mobilesync")
+#define AMSVC_SCREENSHOT            CFSTR("com.apple.screenshotr")
+#define AMSVC_SYSLOG_RELAY          CFSTR("com.apple.syslog_relay")
+#define AMSVC_SYSTEM_PROFILER       CFSTR("com.apple.mobile.system_profiler")
+
+	/* Structure that contains internal data used by AMDevice... functions. Never try
+     * to access its members directly! Use AMDeviceCopyDeviceIdentifier,
+     * AMDeviceGetConnectionID, AMDeviceRetain, AMDeviceRelease instead. */
+    struct AMDevice {
+        CFUUIDBytes _uuid;          /* 0 - Unique Device Identifier */
+        UInt32 _deviceID;           /* 16 */
+        UInt32 _productID;          /* 20 - set to AMD_IPHONE_PRODUCT_ID */
+        CFStringRef _serial;        /* 24 - serial string of device */
+        UInt32 _unknown0;           /* 28 */
+        UInt32 _unknown1;           /* 32 - reference counter, increased by AMDeviceRetain, decreased by AMDeviceRelease */
+        UInt32 _lockdownConnection; /* 36 */
+        UInt8 _unknown2[8];         /* 40 */
+#if (__ITUNES_VER > 740)
+        UInt32 _unknown3;           /* 48 - used to store CriticalSection Handle*/
+#if (__ITUNES_VER >= 800)
+        UInt8 _unknown4[24];        /* 52 */
+#endif
+#endif
+    } __PACK;
+    typedef struct __AMDevice AMDevice;
+    typedef const AMDevice *AMDeviceRef;
+
+    struct __AMDeviceNotificationCallbackInfo;
+    typedef void (*AMDeviceNotificationCallback)(struct __AMDeviceNotificationCallbackInfo *, int _cookie);
+
+    struct __AMDeviceNotification {
+        UInt32 _unknown0;                       /* 0  */
+        UInt32 _unknown1;                       /* 4  */
+        UInt32 _unknown2;                       /* 8  */
+        AMDeviceNotificationCallback _callback; /* 12 */
+        UInt32 _cookie;                         /* 16 */
+    } __PACK;
+    typedef struct __AMDeviceNotification AMDeviceNotification;
+    typedef const AMDeviceNotification *AMDeviceNotificationRef;
+
+    struct __AMDeviceNotificationCallbackInfo {
+        AMDeviceRef _device;                    /* 0 - device */
+        UInt32 _message;                        /* 4 - one of ADNCI_MSG_* */
+        AMDeviceNotificationRef _subscription;  /* 8 */
+    } __PACK;
+    typedef struct __AMDeviceNotificationCallbackInfo AMDeviceNotificationCallbackInfo;
+    typedef AMDeviceNotificationCallbackInfo *AMDeviceNotificationCallbackInfoRef;
+
+	/*  Registers a notification with the current run loop. The callback gets
+	 *  copied into the notification struct, as well as being registered with the
+	 *  current run loop. Cookie gets copied into cookie in the same.
+	 *  (Cookie is a user info parameter that gets passed as an arg to
+	 *  the callback) unused0 and unused1 are both 0 when iTunes calls this.
+	 *
+	 *  Never try to access directly or copy contents of dev and subscription fields
+	 *  in AMDeviceNotificationCallbackInfo. Treat them as abstract handles.
+	 *  When done with connection use AMDeviceRelease to free resources allocated for am_device.
+	 *
+	 *  Returns:
+	 *      MDERR_OK            if successful
+	 *      MDERR_SYSCALL       if CFRunLoopAddSource() failed
+	 *      MDERR_OUT_OF_MEMORY if we ran out of memory
+	 */
+	mach_error_t AMDeviceNotificationSubscribe(AMDeviceNotificationCallback callback,
+                                                           unsigned int unused0, unsigned int unused1,
+                                                           unsigned int cookie,
+                                                           AMDeviceNotificationRef *subscription);
+
+
+    /* Unregisters notifications. Buggy (iTunes 8.2): if you subscribe, unsubscribe and subscribe again, arriving
+     notifications will contain cookie and subscription from 1st call to subscribe, not the 2nd one. iTunes
+     calls this function only once on exit.
+     */
+	mach_error_t AMDeviceNotificationUnsubscribe(AMDeviceNotificationRef subscription);
+
+	/*  Returns serial field of AMDevice structure
+	 */
+	CFStringRef AMDeviceCopyDeviceIdentifier(AMDeviceRef device);
+
+	/*  Connects to the iPhone. Pass in the AMDeviceRef that the
+	 *  notification callback will give to you.
+	 *
+	 *  Returns:
+	 *      MDERR_OK                if successfully connected
+	 *      MDERR_SYSCALL           if setsockopt() failed
+	 *      MDERR_QUERY_FAILED      if the daemon query failed
+	 *      MDERR_INVALID_ARGUMENT  if USBMuxConnectByPort returned 0xffffffff
+	 */
+	mach_error_t AMDeviceConnect(AMDeviceRef device);
+
+    mach_error_t AMDeviceDisconnect(AMDeviceRef device);
+
+	/*  Calls PairingRecordPath() on the given device, than tests whether the path
+	 *  which that function returns exists. During the initial connect, the path
+	 *  returned by that function is '/', and so this returns 1.
+	 *
+	 *  Returns:
+	 *      0   if the path did not exist
+	 *      1   if it did
+	 */
+	mach_error_t AMDeviceIsPaired(AMDeviceRef device);
+	mach_error_t AMDevicePair(AMDeviceRef device);
+
+	/*  iTunes calls this function immediately after testing whether the device is
+	 *  paired. It creates a pairing file and establishes a Lockdown connection.
+	 *
+	 *  Returns:
+	 *      MDERR_OK                if successful
+	 *      MDERR_INVALID_ARGUMENT  if the supplied device is null
+	 *      MDERR_DICT_NOT_LOADED   if the load_dict() call failed
+	 */
+	mach_error_t AMDeviceValidatePairing(AMDeviceRef device);
+
+	/*  Creates a Lockdown session and adjusts the device structure appropriately
+	 *  to indicate that the session has been started. iTunes calls this function
+	 *  after validating pairing.
+	 *
+	 *  Returns:
+	 *      MDERR_OK                if successful
+	 *      MDERR_INVALID_ARGUMENT  if the Lockdown conn has not been established
+	 *      MDERR_DICT_NOT_LOADED   if the load_dict() call failed
+	 */
+	mach_error_t AMDeviceStartSession(AMDeviceRef device);
+
+
+	/* Starts a service and returns a socket file descriptor that can be used in order to further
+	 * access the service. You should stop the session and disconnect before using
+	 * the service. iTunes calls this function after starting a session. It starts
+	 * the service and the SSL connection. service_name should be one of the AMSVC_*
+	 * constants.
+	 *
+	 * Returns:
+	 *      MDERR_OK                if successful
+	 *      MDERR_SYSCALL           if the setsockopt() call failed
+	 *      MDERR_INVALID_ARGUMENT  if the Lockdown conn has not been established
+	 */
+	mach_error_t AMDeviceStartService(AMDeviceRef device, CFStringRef
+                                                  service_name, int *socket_fd);
+
+	/* Stops a session. You should do this before accessing services.
+	 *
+	 * Returns:
+	 *      MDERR_OK                if successful
+	 *      MDERR_INVALID_ARGUMENT  if the Lockdown conn has not been established
+	 */
+	mach_error_t AMDeviceStopSession(AMDeviceRef device);
+
+	/* Decrements reference counter and, if nothing left, releases resources hold
+	 * by connection, invalidates  pointer to device
+	 */
+	void AMDeviceRelease(AMDeviceRef device);
+
+	/* Increments reference counter
+	 */
+	void AMDeviceRetain(AMDeviceRef device);
+
+
+// The following function prototype is reproduced from https://github.com/imkira/mobiledevice/blob/master/mobiledevice.h .
+    int AMDeviceSecureUninstallApplication(int unknown0, AMDeviceRef device, CFStringRef bundle_id,
+                                           int unknown1, void *callback, int callback_arg);
+
+
+// The following function prototypes are inferred from those functions' usage
+// in https://github.com/ghughes/fruitstrap/blob/master/fruitstrap.c .
+// Comments are by Inkling Systems, Inc.
+    /* `socket_fd` is the file descriptor returned (by reference) by `AMDeviceStartService` called with `AMSVC_AFC` for `service_name` */
+    int AMDeviceTransferApplication(int socket_fd, CFStringRef path,
+                                    CFDictionaryRef options, void *callback, int callback_arg);
+    /* `socket_fd` is the file descriptor returned (by reference) by `AMDeviceStartService` called with `CFSTR("com.apple.mobile.installation_proxy")` for `service_name` */
+    int AMDeviceInstallApplication(int socket_fd, CFStringRef path,
+                                   CFDictionaryRef options, void *callback, int callback_arg);
+
+#endif

--- a/Supporting Files/CI/device-install.m
+++ b/Supporting Files/CI/device-install.m
@@ -1,0 +1,367 @@
+/*/../bin/ls > /dev/null
+# This comment is a shell script to self-compile this `.m` file.
+# It allows the file to be directly invoked with arguments.
+# Thanks to http://bou.io/HowToWriteASelfCompilingObjectiveCFile.html for explanation.
+
+
+#  For details and documentation:
+#  http://github.com/inkling/Subliminal
+#
+#  Copyright 2013 Inkling Systems, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+# `device-install` installs and uninstalls applications onto/from devices.
+#
+# `device-install` is modeled after the [`mobiledevice`](https://github.com/imkira/mobiledevice) and
+# [`fruitstrap`](https://github.com/ghughes/fruitstrap) libraries. It differs from those projects primarily
+# in its focus: it is not meant to serve as a general device manager that supports debugging, tunneling, etc.,
+# or even to provide utilities like reporting a device's identifier or installed applications, but 
+# solely to install and uninstall applications.
+#
+# Execute `device-install.m` with no arguments to print usage.
+
+
+COMPILED=${0%.*}
+clang "$0" -fobjc-arc -framework Foundation -framework MobileDevice -F/System/Library/PrivateFrameworks -o "$COMPILED"
+if [ $? -eq 0 ]; then
+    "$COMPILED" "$@"; EXIT_STATUS=$?; rm "$COMPILED"
+    exit $EXIT_STATUS
+else
+    exit 1
+fi
+*/
+
+
+#import <Foundation/Foundation.h>
+#import <getopt.h>
+#import "device-install.h"
+
+
+#pragma mark - Usage
+
+void printUsage(const char *app) {
+    const char *usage = ""
+    "usage: %s -i/--hw_id <udid> -a/--app <app> [-t/--timeout <timeout>] <command>\n"
+    "\n"
+    "   arguments:\n"
+    "       -i/--hw_id <udid>       The UDID of the device on which to install, or from which to uninstall,\n"
+    "                               an application. `device-install` will wait for this device to connect,\n"
+    "                               if it is not already connected, for a duration determined by `timeout`.\n"
+    "\n"
+    "       -a/--app <app>          The full path to the application that is to be installed on, or uninstalled\n"
+    "                               from, the device. This application must be built for an iOS device (as opposed\n"
+    "                               to the simulator) and must be code-signed with a valid identity.\n"
+    "                               (If you have set such an identity in your project's settings, Xcode will\n"
+    "                               sign the application when it builds it for device.)\n"
+    "\n"
+    "       -t/--timeout <timeout>  The maximum duration for which to wait, in seconds, for the specified device\n"
+    "                               to connect before aborting. This value is optional; if not specified,\n"
+    "                               `device-install will wait indefinitely.\n"
+    "\n"
+    "   commands:\n"
+    "       install                 Installs the specified application on the specified device.\n"
+    "                               If the application is already installed, it will be updated (just like\n"
+    "                               repeatedly building and running on device from Xcode.)\n"
+    "\n"
+    "       uninstall               Uninstalls the specified application from the specified device.\n"
+    "                               More specifically, the application with bundle ID matching that of the\n"
+    "                               specified application (if any) will be uninstalled.\n"
+    "\n"
+    "                               Note that this command will print log messages as if such an application\n"
+    "                               is being uninstalled, even if none was actually installed prior to\n"
+    "                               `device-install being invoked.\n"
+    "\n";
+    fprintf(stderr, usage, app);
+}
+
+
+#pragma mark - Definitions
+
+#define DIAssert(condition, ...)\
+do {\
+    if (!(condition)) {\
+        fprintf(stderr, __VA_ARGS__);\
+        unregisterForDeviceNotifications();\
+        exit(1);\
+    }\
+} while (0)
+
+typedef NS_ENUM(NSUInteger, CommandType) {
+    InstallApp,
+    UninstallApp
+};
+
+struct {
+    CommandType command;
+    const char *deviceId;
+    const char *appPath;
+    double timeout;
+
+    AMDeviceNotificationRef notification;
+    BOOL foundDevice;
+} __run;
+
+
+#pragma mark - Functions
+
+#pragma mark -Utility functions
+
+// This must be declared at top so it can be called by DIAssert
+void unregisterForDeviceNotifications() {
+    AMDeviceNotificationUnsubscribe(__run.notification);
+}
+
+void withDeviceConnected(AMDeviceRef device, void(^connectionHandler)(BOOL didConnect, AMDeviceRef device)) {
+    BOOL errorOccurred = AMDeviceConnect(device);
+
+    errorOccurred = errorOccurred || !AMDeviceIsPaired(device); // unlike the other functions, this returns 1 on success
+    errorOccurred = errorOccurred || AMDeviceValidatePairing(device);
+    errorOccurred = errorOccurred || AMDeviceStartSession(device);
+
+    connectionHandler(!errorOccurred, device);
+    if (errorOccurred) return;
+
+    DIAssert(AMDeviceStopSession(device) == 0, "Could not stop session.\n");
+    DIAssert(AMDeviceDisconnect(device) == 0, "Could not disconnect from device.\n");
+}
+
+#pragma mark -Uninstallation
+
+void uninstallCallback(CFDictionaryRef cfInfo, int arg) {
+    // begin a new autorelease pool because this is a callback
+    @autoreleasepool {
+        NSDictionary *info = (__bridge NSDictionary *)cfInfo;
+
+        // only print the "removing application" status (at ~50%) because there's only two others,
+        // one at 0%--and we already print a 0% message--and one at 90% that's not very informative
+        NSString *status = info[@"Status"];
+        if ([status isEqualToString:@"RemovingApplication"]) {
+            int percent = [info[@"PercentComplete"] intValue];
+            printf("[%3d%%] %s\n", percent, "Removing the application");
+        }
+    }
+}
+
+void uninstallApp(AMDeviceRef device) {
+    NSString *infoPlistPath = [@(__run.appPath) stringByAppendingPathComponent:@"Info.plist"];
+    NSDictionary *infoPlist = [NSDictionary dictionaryWithContentsOfFile:infoPlistPath];
+    DIAssert(infoPlist, "App at path '%s' does not appear to be valid: 'Info.plist' is missing.\n", __run.appPath);
+    NSString *bundleId = infoPlist[@"CFBundleIdentifier"];
+
+    printf("[  0%%] Uninstalling app (%s) with bundle ID %s\n", __run.appPath, [bundleId UTF8String]);
+
+    withDeviceConnected(device, ^(BOOL didConnect, AMDeviceRef dev) {
+        DIAssert(didConnect, "Could not connect to device.\n");
+
+        // in contrast to installation, it seems that uninstallation requires being connected
+        // plus we're not using a service. perhaps there is one that would let us uninstall unconnected
+        DIAssert(AMDeviceSecureUninstallApplication(0, dev, (__bridge CFStringRef)bundleId, 0, &uninstallCallback, 0) == 0, "Could not uninstall application.\n");
+    });
+
+    printf("[100%%] Uninstalled %s\n", __run.appPath);
+    unregisterForDeviceNotifications();
+    exit(0);
+}
+
+#pragma mark -Installation
+
+void transferCallback(CFDictionaryRef cfInfo, int arg) {
+    // begin a new autorelease pool because this is a callback
+    @autoreleasepool {
+        NSDictionary *info = (__bridge NSDictionary *)cfInfo;
+
+        int percent = [info[@"PercentComplete"] intValue];
+        int scaledPercent = percent / 2;    // transfer is only half the installation process
+
+        // only print statuses about copying files
+        // because the other ones are just "PreflightingTransfer" at 0%--and we already print a 0% message--
+        // and "TransferringPackage" at the same percentage as the first file copied
+        NSString *status = info[@"Status"];
+        if ([status isEqualToString:@"CopyingFile"]) {
+            NSString *path = info[@"Path"];
+            // we may receive multiple callbacks while copying big files
+            // but we only want to print one update per file
+            static NSString *__lastPath = nil;
+            if (!__lastPath || ![path isEqualToString:__lastPath]) {
+                printf("[%3d%%] Copying %s to device\n", scaledPercent, [path UTF8String]);
+            }
+            __lastPath = path;
+        }
+    }
+}
+
+void installCallback(CFDictionaryRef cfInfo, int arg) {
+    // begin a new autorelease pool because this is a callback
+    @autoreleasepool {
+        NSDictionary *info = (__bridge NSDictionary *)cfInfo;
+
+        int percent = [info[@"PercentComplete"] intValue];
+        int scaledPercent = percent / 2 + 50;    // this is the second half of the installation process
+        printf("[%3d%%] %s\n", scaledPercent, [info[@"Status"] UTF8String]);
+    }
+}
+
+void installApp(AMDeviceRef device) {
+    printf("[  0%%] Installing %s\n", __run.appPath);
+
+    CFStringRef appPath = (__bridge CFStringRef)@(__run.appPath);
+
+    // copy app to device
+    __block int afcFd;
+    withDeviceConnected(device, ^(BOOL didConnect, AMDeviceRef dev) {
+        DIAssert(didConnect, "Could not connect to device.\n");
+
+        AMDeviceStartService(dev, AMSVC_AFC, &afcFd);
+
+        // documentation on `AMDeviceStartService` says that we should disconnect before using the service
+        // (in the transfer); also the transfer works without being connected
+    });
+    DIAssert(AMDeviceTransferApplication(afcFd, appPath, NULL, &transferCallback, 0) == 0, "Could not copy the app to the device.\n");
+    close(afcFd);
+
+    // install the app on the device
+    __block int installFd;
+    withDeviceConnected(device, ^(BOOL didConnect, AMDeviceRef dev) {
+        DIAssert(didConnect, "Could not connect to device.\n");
+        
+        // There's no AMSVC value defined for the installation proxy
+        AMDeviceStartService(dev, CFSTR("com.apple.mobile.installation_proxy"), &installFd);
+
+        // documentation on `AMDeviceStartService` says that we should disconnect before using the service
+        // (in the installation); also the installation works without being connected
+    });
+    NSDictionary *installOptions = @{ @"PackageType": @"Developer" };
+    DIAssert(AMDeviceInstallApplication(installFd, appPath, (__bridge CFDictionaryRef)installOptions, &installCallback, 0) == 0, "Could not install application.\n");
+    close(installFd);
+
+    printf("[100%%] Installed %s\n", __run.appPath);
+    unregisterForDeviceNotifications();
+    exit(0);
+}
+
+#pragma mark -Startup
+
+void handleDeviceConnection(AMDeviceRef device) {
+    // ignore devices other than that specified by the user
+    NSString *udid = CFBridgingRelease(AMDeviceCopyDeviceIdentifier(device));
+    if (![udid isEqualToString:@(__run.deviceId)]) return;
+    __run.foundDevice = YES;
+
+    switch (__run.command) {
+        case InstallApp:
+            installApp(device);
+            break;
+        case UninstallApp:
+            uninstallApp(device);
+            break;
+    }
+}
+
+void deviceNotificationCallback(AMDeviceNotificationCallbackInfoRef info, int cookie) {
+    // begin a new autoreleasepool because this is a callback
+    @autoreleasepool {
+        switch (info->_message) {
+            case ADNCI_MSG_CONNECTED:
+                handleDeviceConnection(info->_device);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+void registerForDeviceNotifications() {
+    const char *timeoutDescription = "";
+    if (__run.timeout > 0) {
+        timeoutDescription = [[NSString stringWithFormat:@"up to %g seconds ", __run.timeout] UTF8String];
+    }
+    printf("[....] Waiting %sfor device %s to connect...\n", timeoutDescription, __run.deviceId);
+
+    AMDeviceNotificationSubscribe(&deviceNotificationCallback, 0, 0, 0, &__run.notification);
+
+    // wait for a device to connect (or for us to receive a notification of an already-connected device)
+    if (__run.timeout > 0) {
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, __run.timeout, false);
+        DIAssert(__run.foundDevice, "Timed out waiting for device to connect.\n");
+    } else {
+        // wait indefinitely
+        CFRunLoopRun();
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    #define DIAssertUsage(condition, ...)\
+    do {\
+        if (!(condition)) {\
+            fprintf(stderr, __VA_ARGS__);\
+            printUsage(argv[0]);\
+            exit(1);\
+        }\
+    } while (0)
+
+    @autoreleasepool
+    {
+        // If the script was invoked with no arguments, print usage and die
+        DIAssertUsage(argc > 1, "");
+
+        // Parse options and command
+        const struct option longopts[] = {
+            { "hw_id",  required_argument, NULL, 'i' },
+            { "app",    required_argument, NULL, 'a' },
+            { "timeout",required_argument, NULL, 't' },
+            { NULL, 0, NULL, 0 }
+        };
+
+        char ch;
+        while ((ch = getopt_long(argc, argv, "i:a:t:", longopts, NULL)) != -1) {
+            switch (ch) {
+                case 'i':
+                    __run.deviceId = optarg;
+                    break;
+                case 'a': {
+                    NSString *appPath = [@(optarg) stringByStandardizingPath];
+                    DIAssertUsage([[NSFileManager defaultManager] fileExistsAtPath:appPath], "App does not exist at specified path.\n");
+                    __run.appPath = [appPath UTF8String];
+                }   break;
+                case 't':
+                    __run.timeout = atof(optarg);
+                    break;
+                default:
+                    // getopt_long will log an error for us
+                    DIAssertUsage(NO, "");
+                    break;
+            }
+        }
+
+        // assert that the user specified the required arguments
+        DIAssertUsage(__run.deviceId && __run.appPath, "You must specify a UDID and app path.\n");
+
+        DIAssertUsage(optind < argc, "%s requires a command\n", argv[0]);
+        NSString *commandType = @(argv[optind]);
+        if ([commandType isEqualToString:@"install"]) {
+            __run.command = InstallApp;
+        } else if ([commandType isEqualToString:@"uninstall"]) {
+            __run.command = UninstallApp;
+        } else {
+            DIAssertUsage(NO, "Unrecognized command: %s\n", [commandType UTF8String]);
+        }
+
+        // Wait for device to connect
+        registerForDeviceNotifications();
+    }
+    return 0;
+}

--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -152,6 +152,10 @@ if [[ -z $1 ]]; then
 	print_usage_and_fail
 fi
 
+# Determine this script's directory, so that the script
+# may look up and invoke supporting scripts
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+
 
 ### Parse arguments
 
@@ -276,13 +280,68 @@ enable_SDK_version_or_all () {
 	fi
 }
 
+# resets the simulator, or uninstalls the app from the device 
+# (the best that we can do, given device support
+# --also probably better not to be as destructive as a reset on a device)
+# This function must be declared here to be called from `cleanup_and_exit`
+reset_simulator_or_device () {
+	local reset_success=0
+	
+	if [[ -n "$SIM_DEVICE" ]]; then
+		"$SCRIPT_DIR/reset_simulator"
+		reset_success=$?
+		if [ $reset_success -eq 0 ]; then
+			echo "Successfully reset iOS Simulator."
+		else
+			echo "\nERROR: Could not reset the simulator."
+		fi
+	else
+		# `device-install` requires that we specify the app, 
+		# so if we haven't built it yet just return 
+		# (we obviously haven't installed it anyway)
+		[ -z "$APP" ] && return 0
+
+		# It's safe to ask `device-install.m` to uninstall the app even if 
+		# it's not currently installed, though (`device-install.m` will still return success)
+		local timeout_arg=`[[ -n "$TIMEOUT" ]] && echo "--timeout $TIMEOUT" || echo ""`
+		"$SCRIPT_DIR/device-install.m" --hw_id $HW_ID --app "$APP" $timeout_arg uninstall
+		reset_success=$?
+		if [ $reset_success -eq 0 ]; then
+			echo "\nSuccessfully uninstalled the application from the device."
+		else
+			echo "\nERROR: Could not uninstall the app from the device."
+		fi
+	fi
+	return $reset_success
+}
+
+# (Re)installs the application on the device
+# as instruments will not do this
+# Declared here just for proximity to `reset_simulator_or_device`
+reinstall_app_on_device () {
+	local reinstall_success=0
+	
+	# Uninstall app
+	echo ""
+	reset_simulator_or_device
+	reinstall_success=$?
+	[ $reinstall_success -eq 0 ] || return $reinstall_success
+	
+	# Install app
+	echo ""
+	local timeout_arg=`[[ -n "$TIMEOUT" ]] && echo "--timeout $TIMEOUT" || echo ""`
+	"$SCRIPT_DIR/device-install.m" --hw_id $HW_ID --app "$APP" $timeout_arg install
+	reinstall_success=$?
+	if [ $reinstall_success -eq 0 ]; then
+		echo "\nSuccessfully installed the application on the device."
+	else
+		echo "\nERROR: Could not install the application on the device."
+	fi
+	return $reinstall_success
+}
+
 # This function allows the script to abort at any point below without duplicating cleanup logic
 cleanup_and_exit () {
-	# Remove temporary files
-	[[ -n "$BUILD_DIR" ]] && rm -rf "$BUILD_DIR"
-	[[ -n "$BUILD_LOG" ]] && rm -rf "$BUILD_LOG"
-	[[ -n "$RUN_DIR" ]] && rm -rf "$RUN_DIR"
-
 	# Re-enable all simulator SDKs if necessary
 	echo ""
 	enable_SDK_version_or_all
@@ -299,19 +358,30 @@ cleanup_and_exit () {
 		fi
 	fi
 
-	if [[ -n "$SIM_DEVICE" ]]; then
-		# Reset the simulator if the bundle identifier was replaced
-		# due to the risk of collision
-		if [[ -n "$REPLACEMENT_BUNDLE_ID" ]]; then
-			echo "\nResetting simulator content and settings because bundle identifier was replaced..."
-			"$SCRIPT_DIR/reset_simulator"
-			if [ $? -eq 0 ]; then
-				echo "Successfully reset iOS Simulator."
-			else
-				echo "\nERROR: Could not reset the simulator."
-			fi
+	# Reset the project's bundle identifier if it was replaced
+	# And reset the simulator/device due to the risk of collision
+	if [[ -n "$REPLACEMENT_BUNDLE_ID" ]]; then
+		if [[ -n "$DEFAULT_BUNDLE_ID" ]]; then
+			echo "Setting target bundle identifier back to '$DEFAULT_BUNDLE_ID'..."
+
+			/usr/libexec/plistbuddy -c "Set :CFBundleIdentifier $DEFAULT_BUNDLE_ID" "$INFO_PLIST_PATH"
 		fi
+
+		if [[ -n "$SIM_DEVICE" ]]; then
+			echo "\nResetting simulator content and settings because the bundle identifier was replaced..."
+		else
+			echo "\nUninstalling application from the device because the bundle identifier was replaced..."
+		fi
+		reset_simulator_or_device
 	fi
+
+	# Remove temporary files
+	# This must be done after the device is potentially reset, 
+	# because that process requires access to the application being uninstalled
+	[[ -n "$BUILD_DIR" ]] && rm -rf "$BUILD_DIR"
+	[[ -n "$BUILD_LOG" ]] && rm -rf "$BUILD_LOG"
+	[[ -n "$RUN_DIR" ]] && rm -rf "$RUN_DIR"
+	echo ""
 
 	exit $1
 }
@@ -319,6 +389,7 @@ trap "cleanup_and_exit 1" SIGINT SIGTERM
 
 
 ### Build app
+
 QUIETLY=`([[ -n "$QUIET_BUILD" ]] && $QUIET_BUILD) && echo " (quietly)" || echo ""`
 echo "\n\nBuilding app$QUIETLY..."
 
@@ -357,11 +428,16 @@ build_app () {
 	[[ -n "$BUILD_DIR" ]] && rm -rf "$BUILD_DIR"
 	[[ -n "$BUILD_LOG" ]] && rm -rf "$BUILD_LOG"
 
+	# Reset the project's bundle identifier if it was changed before a previous build
+	if [[ -n "$DEFAULT_BUNDLE_ID" ]]; then
+		/usr/libexec/plistbuddy -c "Set :CFBundleIdentifier $DEFAULT_BUNDLE_ID" "$INFO_PLIST_PATH"
+	fi
+
 	# Controlling where Xcode builds the app lets us determine where to point instruments to
 	BUILD_DIR=`mktemp -d /tmp/subliminal-test.build.XXXXXX`
 	if [ $? -ne 0 ]; then
 		echo "\nERROR: Could not create build directory."
-		cleanup_and_exit 1
+		return 1
 	fi
 
 	# Create a file to log the build output to if necessary
@@ -383,6 +459,18 @@ build_app () {
 			VALIDATE_PRODUCT=NO $1
 	}
 
+	# Change the app's bundle identifier if a replacement was specified
+	# Do this before building so that if we don't have to re-codesign the executable
+	# If we're building for device
+	if [[ -n "$REPLACEMENT_BUNDLE_ID" ]]; then
+		echo "\nSetting target bundle identifier to '$REPLACEMENT_BUNDLE_ID'..."
+
+		INFO_PLIST_PATH=`build_base_command -showBuildSettings | grep INFOPLIST_FILE | awk 'BEGIN {FS=" = ";} {print $2}'`
+		# Use `plistbuddy` because `INFO_PLIST_PATH` may be an absolute _or_ relative path
+		DEFAULT_BUNDLE_ID=`/usr/libexec/plistbuddy -c "Print :CFBundleIdentifier" "$INFO_PLIST_PATH"`
+		/usr/libexec/plistbuddy -c "Set :CFBundleIdentifier $REPLACEMENT_BUNDLE_ID" "$INFO_PLIST_PATH"
+	fi
+
 	# build in a subshell to conditionally redirect its output (and only its output)
 	# to the build log, if one has been created
 	(
@@ -395,28 +483,22 @@ build_app () {
 		[[ -e "$BUILD_LOG" ]] && cat "$BUILD_LOG"
 
 		echo "\nERROR: Could not build application."
-		cleanup_and_exit 1
+		return 1
 	fi
 
 	# Note that instruments will install the app in the Simulator when launched
 	APP=`find "$BUILD_DIR" -name "*.app"`
 
-	# Change the app's bundle identifier if a replacement was specified
-	if [[ -n "$REPLACEMENT_BUNDLE_ID" ]]; then
-	    INFO_PLIST_PATH=`build_base_command -showBuildSettings | grep INFOPLIST_PATH | awk 'BEGIN {FS=" = ";} {print $2}'`
-	    INFO_PLIST_NAME=`basename "$INFO_PLIST_PATH"`
-	    INFO_PLIST="$APP/$INFO_PLIST_NAME"
-		defaults write "$INFO_PLIST" CFBundleIdentifier "$REPLACEMENT_BUNDLE_ID"
-	fi
+	return 0
 }
 build_app
+[ $? -eq 0 ] || cleanup_and_exit 1
 
 
-### Prepare to install app
-echo "\n\nPreparing to install app..."
+### (Prepare to) install app
 
 if [[ -n "$SIM_DEVICE" ]]; then
-	SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+	echo "\n\nPreparing to install app..."
 
 	# Set the simulator's device type
 	echo "\nSetting simulator device type..."
@@ -454,14 +536,14 @@ if [[ -n "$SIM_DEVICE" ]]; then
 	# This has got to be done after setting the simulator's version
 	# so that we wipe the appropriate content and settings
 	echo "\nResetting simulator content and settings..."
-	"$SCRIPT_DIR/reset_simulator"
-	if [ $? -eq 0 ]; then
-		echo "Successfully reset iOS Simulator."
-	else
-		echo "\nERROR: Could not reset the simulator."
-		cleanup_and_exit 1
-	fi
+	reset_simulator_or_device
+
+	# instruments will actually install the app in the simulator
+else
+	echo "\n\nInstalling app..."
+	reinstall_app_on_device
 fi
+[ $? -eq 0 ] || cleanup_and_exit 1
 
 # Set paths to save instruments' output (at least temporarily)
 RUN_DIR=`mktemp -d /tmp/subliminal-test.run.XXXXXX`
@@ -475,6 +557,7 @@ mkdir "$RESULTS_DIR"
 
 
 ### Launch tests
+
 echo "\n\nLaunching tests...\n"
 
 # Temporarily disable UIAutomation's debug logging unless directed otherwise
@@ -524,24 +607,28 @@ if [ $? -ne 0 ] && [ ! -e "$RESULT_LOG" ]; then
 	#
 	# We retry once, after resetting the simulator and rebuilding the app--
 	# the error may be caused by instruments rejecting the build for some reason.
-	echo "\ninstruments hiccuped; retrying with clean build...\n"
+	echo "\ninstruments hiccuped; retrying with clean build...\n"	
 
-	# Reset the simulator in case instruments installed the app and then aborted
-	"$SCRIPT_DIR/reset_simulator"
-	if [ $? -ne 0 ]; then
-		echo "\nERROR: Could not reset the simulator."
-		cleanup_and_exit 1
-	fi
-
-	# Re-enable all simulator SDKs while we build
+	# Re-enable all simulator SDKs (if necessary) while we build
 	echo ""
 	enable_SDK_version_or_all
 	echo ""
+
 	build_app
+	[ $? -eq 0 ] || cleanup_and_exit 1
 
 	# Now once again disable those other than the one we're targeting
 	[[ -n "$SIM_VERSION" ]] && enable_SDK_version_or_all "$SIM_VERSION"
 	echo ""
+
+	# Reset the simulator/reinstall the app on the device 
+	# in case instruments installed the app and then aborted
+	if [[ -n "$SIM_DEVICE" ]]; then
+		reset_simulator_or_device
+	else
+		reinstall_app_on_device
+	fi
+	[ $? -eq 0 ] || cleanup_and_exit 1
 
 	launch_instruments
 	if [ $? -ne 0 ]; then
@@ -552,6 +639,7 @@ fi
 
 
 ### Process results
+
 echo "\n\nProcessing results..."
 
 # Parse test success or failure out of the result log


### PR DESCRIPTION
`instruments` will profile an application on a device only if that application is already installed on the device. This could and did run unnoticed if you already had the application you were testing installed on your device i.e. from Xcode. Now Subliminal (re)installs the application under test on the target device by using Apple's `MobileDevice` framework.
