### PR TITLE
`set_simulator_device` only quotes the device type if necessary.

### DIFF
--- a/Supporting Files/CI/set_simulator_device
+++ b/Supporting Files/CI/set_simulator_device
@@ -35,7 +35,10 @@ if [[ -z "$DEVICE" ]]; then
 fi
 
 # Change device type
-defaults write com.apple.iphonesimulator SimulateDevice "'$DEVICE'"
+# If the device type contains punctuation, it needs to be single-quoted to be written into the plist
+# but we only quote it if necessary, because the simulator rejects e.g. "'iPhone'"
+SAFE_DEVICE=`[[ "$DEVICE" =~ [[:punct:]] ]] && echo "'$DEVICE'" || echo "$DEVICE"`
+defaults write com.apple.iphonesimulator SimulateDevice "$SAFE_DEVICE"
 
 # Restart simulator
 killall "iPhone Simulator" 2> /dev/null


### PR DESCRIPTION
Both the Xcode 4 and 5 Simulators reject e.g. "'iPhone'" . It went unnoticed
that `set_simulator_device` wasn't working for "iPhone" and "iPad" because
`subliminal_test` forces the project to build using particular device families
and "iPhone" and "iPad" are the default device types for their respective families.

Investigation reveals that it's not whitespace but rather punctuation in plist values
that requires quoting so that's updated too--now `set_simulator_device` will
be able to set the Xcode 5 Simulator to "iPad Retina".
