### PR TITLE
Test order is now fully randomized. (closes #78)

### DIFF
--- a/Integration Tests/SLIntegrationTestsAppDelegate.m
+++ b/Integration Tests/SLIntegrationTestsAppDelegate.m
@@ -39,7 +39,7 @@
 @end
 
 @implementation SLIntegrationTestsAppDelegate {
-    NSSet *_tests;
+    NSArray *_tests;
     NSString *_terminalStartupResult;
 }
 
@@ -53,10 +53,10 @@
     if (DEBUG_TEST_CASE_VIEW_CONTROLLER_CLASS) {
         rootViewController = [[DEBUG_TEST_CASE_VIEW_CONTROLLER_CLASS alloc] initWithTestCaseWithSelector:DEBUG_TEST_CASE];
     } else {
-        // Filter the tests for the SLTestController
-        // so that the SLTestsViewController only displays appropriate tests
-        _tests = [SLTestController testsToRun:[SLTest allTests] withFocus:NULL];
-        rootViewController = [[SLTestsViewController alloc] initWithTests:[_tests allObjects]];
+        // Filter the tests for the `SLTestController`
+        // so that the `SLTestsViewController` only displays appropriate tests
+        _tests = [SLTestController testsToRun:[SLTest allTests] usingSeed:NULL withFocus:NULL];
+        rootViewController = [[SLTestsViewController alloc] initWithTests:_tests];
     }
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:rootViewController];
     self.window.rootViewController = navController;
@@ -102,7 +102,7 @@
     }
 
     // Otherwise, run the tests
-    [[SLTestController sharedTestController] runTests:_tests withCompletionBlock:nil];
+    [[SLTestController sharedTestController] runTests:[NSSet setWithArray:_tests] withCompletionBlock:nil];
 }
 
 // Called both by the UIAlertView callback below and the NSTimer above

--- a/Sources/Classes/Internal/SLTestController+Internal.h
+++ b/Sources/Classes/Internal/SLTestController+Internal.h
@@ -34,19 +34,31 @@
 /// ----------------------------------------
 
 /**
- Given a set of tests, returns a new set filtered to those that should be run.
+ Given a set of tests, returns an array ordered by the specified seed 
+ and filtered to those that should be run.
  
- The set of tests is filtered:
+ The set of tests is sorted and randomized using the specified seed. 
+ The resulting array is then filtered:
  
- 1. to those that [are concrete](+[SLTest isAbstract]),
+ 1. to those tests that [are concrete](+[SLTest isAbstract]),
  2. that [support the current platform](+[SLTest supportsCurrentPlatform]),
  3. and that [are focused](+[SLTest isFocused]) (if any remaining are focused).
  
- @param tests The set of `SLTest` subclasses to process.
- @param withFocus If this is non-`NULL`, upon return, it will be set to `YES`
- if any of the tests [are focused](+[SLTest isFocused]), `NO` otherwise.
- @return A filtered set of tests to run.
+ By sorting prior to filtering, the relative order of tests is maintained 
+ regardless of focus.
+
+ @param tests       The set of `SLTest` subclasses to process.
+
+ @param seed        The seed to use to randomize the test order. If this is null, or points to a value of
+                    `SLTestControllerRandomSeed`, the test controller will choose a seed.
+                    If this is non-null, upon return, it will be set to the seed that was used to randomize 
+                    the order (whether chosen by the test controller, or specified by the client).
+ 
+ @param withFocus   If this is non-`NULL`, upon return, it will be set to `YES`
+                    if any of the tests [are focused](+[SLTest isFocused]), `NO` otherwise.
+
+ @return            A filtered and ordered array of tests to run.
  */
-+ (NSSet *)testsToRun:(NSSet *)tests withFocus:(BOOL*)withFocus;
++ (NSArray *)testsToRun:(NSSet *)tests usingSeed:(inout unsigned int *)seed withFocus:(BOOL *)withFocus;
 
 @end

--- a/Sources/Classes/SLTestController.h
+++ b/Sources/Classes/SLTestController.h
@@ -64,21 +64,40 @@
 /// -------------------------------------------
 
 /**
- Run the specified tests.
- 
- Tests are run on a background queue, in indeterminate order.
- Tests must [support the current platform](+[SLTest supportsCurrentPlatform]) 
- in order to be run.
+ Run the specified tests by invoking `runTests:usingSeed:withCompletionBlock:` 
+ with `SLTestControllerRandomSeed` and the specified completion block.
+
+ @param tests The set of tests to run.
+ @param completionBlock An optional block to execute once testing has finished.
+ */
+- (void)runTests:(NSSet *)tests withCompletionBlock:(void (^)())completionBlock;
+
+/**
+ Runs the specified tests.
+
+ Tests are run on a background queue, in an order randomized using the specified seed.
+ Clients should generally pass `SLTestControllerRandomSeed` to let the test controller choose a seed.
+ If any tests fail, the test controller will log the seed that was used,
+ so that the run order may be reproduced by invoking this method with that seed.
+
+ Tests must [support the current platform](+[SLTest supportsCurrentPlatform]) in order to be run.
  If any tests [are focused](+[SLTest isFocused]), only those tests will be run.
  
+ When using a given seed, tests execute in the same relative order regardless of focus.
+ That is, if a set of tests _| A, B, C, D |_ (all unfocused) 
+ are run in order _[ B, A, C, D ]_ when using a certain seed,
+ when tests _B_ and _C_ are focused, they will be run in order _[ B, C ]_.
+
  When all tests have finished, the completion block (if provided)
  will be executed on the main queue. The test controller will then signal 
  UIAutomation to finish executing commands.
-
- @param tests The set of tests to run.
- @param completionBlock An optional block to execute once testing has finished. 
+ 
+ @param tests           The set of tests to run.
+ @param seed            The seed to use to randomize the tests.
+                        If `SLTestControllerRandomSeed` is passed, the test controller will choose a seed.
+ @param completionBlock An optional block to execute once testing has finished.
  */
-- (void)runTests:(NSSet *)tests withCompletionBlock:(void (^)())completionBlock;
+- (void)runTests:(NSSet *)tests usingSeed:(unsigned int)seed withCompletionBlock:(void (^)())completionBlock;
 
 @end
 
@@ -123,3 +142,10 @@
 @property (nonatomic) BOOL shouldWaitToStartTesting;
 
 @end
+
+
+#pragma mark - Constants
+
+/// A value that may be passed to `-runTests:usingSeed:withCompletionBlock:`
+/// to indicate that the test controller should choose a seed.
+extern const unsigned int SLTestControllerRandomSeed;

--- a/Sources/Classes/SLTestController.m
+++ b/Sources/Classes/SLTestController.m
@@ -35,6 +35,8 @@
 #import <objc/runtime.h>
 
 
+const unsigned int SLTestControllerRandomSeed = UINT_MAX;
+
 static NSUncaughtExceptionHandler *appsUncaughtExceptionHandler = NULL;
 static const NSTimeInterval kDefaultTimeout = 5.0;
 
@@ -90,8 +92,9 @@ static void SLUncaughtExceptionHandler(NSException *exception)
 
 @implementation SLTestController {
     dispatch_queue_t _runQueue;
-    BOOL _runningWithFocus;
-    NSSet *_testsToRun;
+    unsigned int _runSeed;
+    BOOL _runningWithFocus, _runningWithPredeterminedSeed;
+    NSArray *_testsToRun;
     NSUInteger _numTestsExecuted, _numTestsFailed;
     void(^_completionBlock)(void);
 
@@ -109,6 +112,17 @@ static void SLUncaughtExceptionHandler(NSException *exception)
 #pragma clang diagnostic pop
 }
 
+// To use a preprocessor macro throughout this file, we'd have to specially build Subliminal
+// when unit testing, e.g. using a "Unit Testing" build configuration
++ (BOOL)isBeingUnitTested {
+    static BOOL isBeingUnitTested = NO;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        isBeingUnitTested = (getenv("SL_UNIT_TESTING") != NULL);
+    });
+    return isBeingUnitTested;
+}
+
 static SLTestController *__sharedController = nil;
 + (instancetype)sharedTestController {
     static dispatch_once_t onceToken;
@@ -118,21 +132,73 @@ static SLTestController *__sharedController = nil;
     return __sharedController;
 }
 
-+ (NSSet *)testsToRun:(NSSet *)tests withFocus:(BOOL *)withFocus {
-    // only run tests that are concrete...
-    NSMutableSet *testsToRun = [NSMutableSet setWithSet:tests];
+/// Produces a portable seed for `random()`, as suggested by
+/// http://eternallyconfuzzled.com/arts/jsw_art_rand.aspx
+unsigned int time_seed(){
+    static time_t previousNow;
+    time_t now = time ( 0 );
+    if ([SLTestController isBeingUnitTested] && (now <= previousNow)) {
+        // when unit testing, this function may be called repeatedly within the temporal resolution of `time`;
+        // we adjust `now` to get different seeds
+        now = previousNow + 1;
+    }
+    previousNow = now;
+
+    unsigned char *p = (unsigned char *)&now;
+    unsigned int seed = 0;
+    size_t i;
+    for (i = 0; i < sizeof now; i++) {
+        seed = seed * ( UCHAR_MAX + 2U ) + p[i];
+    }
+    
+    return seed;
+}
+
+/// a condensed version of the `uniform_deviate` function
+/// also from http://eternallyconfuzzled.com/arts/jsw_art_rand.aspx
+u_int32_t random_uniform(u_int32_t upperBound) {
+    return ( random() / ( RAND_MAX + 1.0 ) ) * upperBound;
+}
+
++ (NSArray *)testsToRun:(NSSet *)tests usingSeed:(inout unsigned int *)seed withFocus:(BOOL *)withFocus {
+    NSMutableArray *testsToRun = [NSMutableArray arrayWithArray:[tests allObjects]];
+
+    // sort the array to produce a consistent basis for randomization
+    [testsToRun sortUsingComparator:^NSComparisonResult(Class test1, Class test2) {
+        // make sure to strip the focus prefix if present
+        NSString *test1Name = [NSStringFromClass(test1) lowercaseString];
+        if ([test1Name hasPrefix:SLTestFocusPrefix]) {
+            test1Name = [test1Name substringFromIndex:[SLTestFocusPrefix length]];
+        }
+        NSString *test2Name = [NSStringFromClass(test2) lowercaseString];
+        if ([test2Name hasPrefix:SLTestFocusPrefix]) {
+            test2Name = [test2Name substringFromIndex:[SLTestFocusPrefix length]];
+        }
+        return [test1Name compare:test2Name];
+    }];
+
+    // randomize the array
+    unsigned int seedSpecified = seed ? *seed : SLTestControllerRandomSeed;
+    unsigned int seedUsed = (seedSpecified == SLTestControllerRandomSeed) ? time_seed() : seedSpecified;
+    if (seed) *seed = seedUsed;
+    srandom(seedUsed);
+    // http://en.wikipedia.org/wiki/Fisher–Yates_shuffle
+    for (NSUInteger i = [testsToRun count] - 1; i > 0; --i) {
+        [testsToRun exchangeObjectAtIndex:i withObjectAtIndex:random_uniform(i + 1)];
+    }
+
+    // now filter the array: only run tests that are concrete...
     [testsToRun filterUsingPredicate:[NSPredicate predicateWithFormat:@"isAbstract == NO"]];
 
     // ...that support the current platform...
     [testsToRun filterUsingPredicate:[NSPredicate predicateWithFormat:@"supportsCurrentPlatform == YES"]];
 
     // ...and that are focused (if any remaining are focused)
-    NSSet *focusedTests = [testsToRun objectsPassingTest:^BOOL(id obj, BOOL *stop) {
-        return [obj isFocused];
-    }];
+    NSMutableArray *focusedTests = [testsToRun mutableCopy];
+    [focusedTests filterUsingPredicate:[NSPredicate predicateWithFormat:@"isFocused == YES"]];
     BOOL runningWithFocus = ([focusedTests count] > 0);
     if (runningWithFocus) {
-        testsToRun = [NSMutableSet setWithSet:focusedTests];
+        testsToRun = focusedTests;
     }
     if (withFocus) *withFocus = runningWithFocus;
 
@@ -146,6 +212,7 @@ static SLTestController *__sharedController = nil;
     if (self) {
         NSString *runQueueName = [NSString stringWithFormat:@"com.inkling.subliminal.SLTestController-%p.runQueue", self];
         _runQueue = dispatch_queue_create([runQueueName UTF8String], DISPATCH_QUEUE_SERIAL);
+        _runSeed = SLTestControllerRandomSeed;
         _defaultTimeout = kDefaultTimeout;
         _startTestingSemaphore = dispatch_semaphore_create(0);
     }
@@ -175,9 +242,7 @@ static SLTestController *__sharedController = nil;
 // user directory path will be different in unit tests than when the application is running).
 - (void)warnIfAccessibilityInspectorIsEnabled {
 #if TARGET_IPHONE_SIMULATOR
-    // To use a preprocessor macro here, we'd have to specially build Subliminal
-    // when unit testing, e.g. using a "Unit Testing" build configuration
-    if (getenv("SL_UNIT_TESTING")) return;
+    if ([SLTestController isBeingUnitTested]) return;
 
     // We detect if the Inspector is enabled by examining the simulator's Accessibility preferences
     // 1. get into the simulator's app support directory by fetching the sandboxed Library's path
@@ -229,8 +294,11 @@ static SLTestController *__sharedController = nil;
     }
 #endif
 
+    if (_runningWithPredeterminedSeed) {
+        SLLog(@"Running tests in order as predetermined by seed %u.", _runSeed);
+    }
     if (_runningWithFocus) {
-        SLLog(@"Focusing on test cases in specific tests: %@.", [[_testsToRun allObjects] componentsJoinedByString:@","]);
+        SLLog(@"Focusing on test cases in specific tests: %@.", [_testsToRun componentsJoinedByString:@","]);
     }
 
     [self warnIfAccessibilityInspectorIsEnabled];
@@ -239,10 +307,16 @@ static SLTestController *__sharedController = nil;
 }
 
 - (void)runTests:(NSSet *)tests withCompletionBlock:(void (^)())completionBlock {
+    [self runTests:tests usingSeed:SLTestControllerRandomSeed withCompletionBlock:completionBlock];
+}
+
+- (void)runTests:(NSSet *)tests usingSeed:(unsigned int)seed withCompletionBlock:(void (^)())completionBlock {
     dispatch_async(_runQueue, ^{
         _completionBlock = completionBlock;
 
-        _testsToRun = [[self class] testsToRun:tests withFocus:&_runningWithFocus];
+        _runningWithPredeterminedSeed = (seed != SLTestControllerRandomSeed);
+        _runSeed = seed;
+        _testsToRun = [[self class] testsToRun:tests usingSeed:&_runSeed withFocus:&_runningWithFocus];
         if (![_testsToRun count]) {
             SLLog(@"%@%@%@", @"There are no tests to run", (_runningWithFocus) ? @": no tests are focused" : @"", @".");
             [self _finishTesting];
@@ -287,6 +361,12 @@ static SLTestController *__sharedController = nil;
     [[SLLogger sharedLogger] logTestingFinishWithNumTestsExecuted:_numTestsExecuted
                                                    numTestsFailed:_numTestsFailed];
 
+    if (_numTestsFailed > 0) {
+        SLLog(@"The run order may be reproduced using seed %u.", _runSeed);
+    }
+    if (_runningWithPredeterminedSeed) {
+        [[SLLogger sharedLogger] logWarning:@"Tests were run in a predetermined order."];
+    }
     if (_runningWithFocus) {
         [[SLLogger sharedLogger] logWarning:@"This was a focused run. Fewer test cases may have run than normal."];
     }
@@ -305,7 +385,9 @@ static SLTestController *__sharedController = nil;
     // clear controller state (important when testing Subliminal, when the controller will test repeatedly)
     _numTestsExecuted = 0;
     _numTestsFailed = 0;
+    _runSeed = SLTestControllerRandomSeed;
     _runningWithFocus = NO;
+    _runningWithPredeterminedSeed = NO;
     _testsToRun = nil;
     _completionBlock = nil;
 

--- a/Subliminal.xcodeproj/project.pbxproj
+++ b/Subliminal.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		0696BA5816E013D600DD70CF /* SLElementDraggingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0696BA5516E013D600DD70CF /* SLElementDraggingTest.m */; };
 		0696BA5916E013D600DD70CF /* SLElementDraggingTestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0696BA5616E013D600DD70CF /* SLElementDraggingTestViewController.m */; };
 		0696BA5A16E013D600DD70CF /* SLElementDraggingTestViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0696BA5716E013D600DD70CF /* SLElementDraggingTestViewController.xib */; };
+		06F49B6117DA946400143D42 /* chisqr.c in Sources */ = {isa = PBXBuildFile; fileRef = 06F49B6017DA946400143D42 /* chisqr.c */; };
 		CA75E78216697A1200D57E92 /* SLDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = CA75E78016697A1200D57E92 /* SLDevice.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA75E78516697C0000D57E92 /* SLDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = CA75E78116697A1200D57E92 /* SLDevice.m */; };
 		CAC388051641CD7500F995F9 /* SLStringUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = CAC388031641CD7500F995F9 /* SLStringUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -240,6 +241,8 @@
 		0696BA5516E013D600DD70CF /* SLElementDraggingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLElementDraggingTest.m; sourceTree = "<group>"; };
 		0696BA5616E013D600DD70CF /* SLElementDraggingTestViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLElementDraggingTestViewController.m; sourceTree = "<group>"; };
 		0696BA5716E013D600DD70CF /* SLElementDraggingTestViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SLElementDraggingTestViewController.xib; sourceTree = "<group>"; };
+		06F49B6017DA946400143D42 /* chisqr.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chisqr.c; sourceTree = "<group>"; };
+		06F49B6517DA947000143D42 /* chisqr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = chisqr.h; sourceTree = "<group>"; };
 		CA75E78016697A1200D57E92 /* SLDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLDevice.h; sourceTree = "<group>"; };
 		CA75E78116697A1200D57E92 /* SLDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLDevice.m; sourceTree = "<group>"; };
 		CAC388031641CD7500F995F9 /* SLStringUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLStringUtilities.h; sourceTree = "<group>"; };
@@ -476,6 +479,8 @@
 		F002BF451698ED8100819291 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				06F49B6517DA947000143D42 /* chisqr.h */,
+				06F49B6017DA946400143D42 /* chisqr.c */,
 				F024BE31168BD70900708350 /* TestUtilities.h */,
 				F024BE32168BD70900708350 /* TestUtilities.m */,
 				F08B87F01685A00400C4FE44 /* SharedSLTests.h */,
@@ -1200,6 +1205,7 @@
 				F0A040131698ECDE009D8157 /* SLTestController+AppContextTests.m in Sources */,
 				F05C51EC171C90B000A381BC /* SLMainThreadRefTests.m in Sources */,
 				F0C59ED81752B1D40051FEF0 /* SLStringUtilitiesTests.m in Sources */,
+				06F49B6117DA946400143D42 /* chisqr.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -37,13 +37,15 @@ subliminal-test (-project <project_path> | -workspace <workspace_path>)
 \`subliminal-test\` builds a scheme contained in an Xcode project or Xcode workspace,
 then tests the product using Subliminal.
 
-\`subliminal-test\` returns failure (non-0) if:
+\`subliminal-test\` returns failure in the following conditions, as indicated by their error codes:
 
-  * the tests did not finish
-  * the tests ran in a focused state (see \`+[SLTest isFocused]\`), because then only a subset of tests may have run
-  * one or more tests failed
+  * 1 - the tests did not finish
+  * 2 - one or more tests failed
+  * 3 - the tests ran in a focused state (see \`+[SLTest isFocused]\`), because then only a subset of tests may have run
+  * 4 - the tests ran using a predetermined seed (see \`-[SLTestController runTests:usingSeed:withCompletionBlock:]\`),
+  	because the predetermined test order may have masked test pollution
 
-Otherwise, it returns success (0).
+Otherwise, \`subliminal-test\` returns success (0).
 
 \`subliminal-test\` expects to be run:
 
@@ -649,6 +651,14 @@ if [ $? -eq 0 ]; then
 	echo "\nERROR: Tests were committed with focus--fewer test cases may have run than normal."
 	TEST_STATUS=3
 else
+	grep -q "Tests were run in a predetermined order." "$RESULT_LOG"
+	if [ $? -eq 0 ]; then
+		echo "\nERROR: Tests were run in a predetermined order, possibly masking test pollution."
+		TEST_STATUS=4
+	fi
+fi
+
+if [ $TEST_STATUS -eq 0 ]; then
 	OVERALL_RESULT=`grep "Testing finished" "$RESULT_LOG"`
 	if [[ -z "$OVERALL_RESULT" ]]; then
 		echo "\nERROR: Tests did not finish."

--- a/Unit Tests/TestUtilities.h
+++ b/Unit Tests/TestUtilities.h
@@ -10,12 +10,21 @@
 #import <Subliminal/Subliminal.h>
 
 /**
- Runs the specified tests and waits, without blocking, for them to finish.
+ Calls `SLRunTestsUsingSeedAndWaitUntilFinished` with `SLTestControllerRandomSeed`.
  
- @param tests The SLTest classes to run.
+ @param tests           The `SLTest` classes to run.
  @param completionBlock The optional completion block to execute after testing finishes.
  */
 extern void SLRunTestsAndWaitUntilFinished(NSSet *tests, void (^completionBlock)());
+
+/**
+ Runs the specified tests using the specified seed and waits, without blocking, for them to finish.
+
+ @param tests           The `SLTest` classes to run.
+ @param seed            The seed to use to run the tests.
+ @param completionBlock The optional completion block to execute after testing finishes.
+ */
+extern void SLRunTestsUsingSeedAndWaitUntilFinished(NSSet *tests, unsigned int seed, void (^completionBlock)());
 
 
 /**

--- a/Unit Tests/TestUtilities.m
+++ b/Unit Tests/TestUtilities.m
@@ -10,8 +10,13 @@
 #import <OCMock/OCMock.h>
 
 void SLRunTestsAndWaitUntilFinished(NSSet *tests, void (^completionBlock)()) {
+    SLRunTestsUsingSeedAndWaitUntilFinished(tests, SLTestControllerRandomSeed, completionBlock);
+}
+
+void SLRunTestsUsingSeedAndWaitUntilFinished(NSSet *tests, unsigned int seed, void (^completionBlock)()) {
     __block BOOL testingHasFinished = NO;
     [[SLTestController sharedTestController] runTests:tests
+                                            usingSeed:seed
                                   withCompletionBlock:^{
                                       if (completionBlock) completionBlock();
                                       testingHasFinished = YES;

--- a/Unit Tests/chisqr.c
+++ b/Unit Tests/chisqr.c
@@ -1,0 +1,58 @@
+//
+//  chisqr.c
+//  Subliminal
+//
+//  Created by Aaron Golden on 9/6/13.
+//  Copyright (c) 2013 Inkling. All rights reserved.
+//
+
+#include "chisqr.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+
+double f(double s, double t) {
+    return pow(t, s - 1.0) * exp(-t);
+}
+
+// Integrates f(s,t) for t = min_t to max_t, taking nsteps integration steps,
+// using Simpson's rule: http://en.wikipedia.org/wiki/Simpson's_rule
+double Integrate(double (*f)(double s, double t), double s, double min_t, double max_t, int nsteps) {
+    const double h = (max_t - min_t) / nsteps;
+
+    double q = f(s, min_t) + f(s, max_t);
+    for (int j = 1; j <= nsteps; j += 2) {
+        q += 4 * f(s, min_t + j * h);
+    }
+    for (int j = 2; j <= nsteps - 1; j += 2) {
+        q += 2 * f(s, min_t + j * h);
+    }
+
+    return q * h / 3.0;
+}
+
+bool ChiIsUniform(double *distribution, size_t distributionLength, size_t degreesOfFreedom, double significance)
+{
+    double expected = 0.0;
+    for (size_t j = 0; j < distributionLength; j++) {
+        expected += distribution[j];
+    }
+    expected /= distributionLength;
+
+    double sum = 0.0;
+    for (size_t j = 0; j < distributionLength; j++) {
+        double x = distribution[j] - expected;
+        sum += x * x;
+    }
+
+    const double chi2DistanceFromUniformDistribution = sum / expected;
+
+    const double max_t = 0.5 * chi2DistanceFromUniformDistribution;
+    const double dof_2 = degreesOfFreedom * 0.5;
+    const int nsteps = max_t / 0.01 + 1;
+    const double lowerIncompleteGamma = Integrate(f, dof_2, 0.0, max_t, nsteps);
+    const double p = 1.0 - lowerIncompleteGamma / tgamma(dof_2);
+
+    return p >= significance;
+}

--- a/Unit Tests/chisqr.h
+++ b/Unit Tests/chisqr.h
@@ -1,0 +1,42 @@
+//
+//  chisqr.h
+//  Subliminal
+//
+//  Created by Aaron Golden on 9/6/13.
+//  Copyright (c) 2013 Inkling. All rights reserved.
+//
+
+#include <stdbool.h>
+#include <sys/types.h>
+
+#ifndef Subliminal_chisqr_h
+#define Subliminal_chisqr_h
+
+/**
+ Determines whether or not a distribution is sufficiently close to a uniform
+ distribution, where "sufficiently close" is determined by the significance
+ parameter.
+
+ @param distribution        An array of doubles that is an observed distribution,
+                            for example every element of distribution might be
+                            an integer specifying the number of times that a
+                            particular element was observed in a sample.
+
+ @param distributionLength  The number of elements in distribution.
+
+ @param degreesOfFreedom    The number of degrees of freedom in the statistic reflected
+                            by distribution.  If the sample reflected by distribution is
+                            not otherwise constrained, degreesOfFreedom should be
+                            distributionLength - 1.
+
+ @param significance        A value controlling the strictness of the uniformity test.
+                            ChiIsUniform will return true if the probability of observing
+                            distribution in a sample taken from a truly uniform distribution
+                            is at least significance.
+
+ @return    true if the probability of observing distribution in a sample taken from a truly
+            uniform distribution is greater than or equal to significance, false otherwise.
+ */
+bool ChiIsUniform(double *distribution, size_t distributionLength, size_t degreesOfFreedom, double significance);
+
+#endif


### PR DESCRIPTION
Tests are now sorted and then randomized prior to being run.
If one or more tests fail, the seed used to randomize the order will be logged.
That seed may then be used to rerun the tests in the same order.

If the seed was predetermined (by the user), a warning will be logged
and `subliminal-test` will fail the run (under the assumption that tests should
generally be run randomized, to prevent test pollution, and that a seed will
be predetermined only for debugging purposes.)

Test relative order will be maintained regardless of focus.
