### PR TITLE
Adds SLSwitch

### DIFF
--- a/Integration Tests/Tests/SLSwitchTest.m
+++ b/Integration Tests/Tests/SLSwitchTest.m
@@ -31,26 +31,27 @@
     [super setUpTestCaseWithSelector:testCaseSelector];
     SLAssertTrue([UIAElement(_aSwitch) isValidAndVisible], @"Switch should be valid and visible");
     SLAssertTrue([UIAElement(_aSwitch) isTappable], @"Switch should be tappable");
-    [_aSwitch setValue:ON];
+    [_aSwitch setOn:YES];
 }
 
-- (void)testSLSwitchSetValue
+- (void)testSLSwitchSetOn
 {
-    [_aSwitch setValue:OFF];
+    [_aSwitch setOn:NO];
     SLAssertTrue([[_aSwitch value] boolValue] == NO, @"Switch value was not set to OFF");
-    [_aSwitch setValue:ON];
+    [_aSwitch setOn:YES];
     SLAssertTrue([[_aSwitch value] boolValue] == YES, @"Switch value was not set to ON");
 }
 
 - (void)testSLSwitchIsOn
 {
-    [_aSwitch setValue:OFF];
+    [_aSwitch setOn:NO];
     SLAssertTrue([_aSwitch isOn] == NO, @"Switch should be OFF");
-    [_aSwitch setValue:ON];
+    [_aSwitch setOn:YES];
     SLAssertTrue([_aSwitch isOn] == YES, @"Switch should be ON");
 }
 
-- (void)testSLSwitchCanToggleWithTap {
+- (void)testSLSwitchCanToggleWithTap
+{
     BOOL value = [_aSwitch.value boolValue];
     [_aSwitch tap];
     SLAssertFalse(value == [_aSwitch.value boolValue], @"Value should have changed");

--- a/Integration Tests/Tests/SLSwitchTest.m
+++ b/Integration Tests/Tests/SLSwitchTest.m
@@ -1,0 +1,61 @@
+//
+//  SLSwitchTest.m
+//  Subliminal
+//
+//  Created by Justin Mutter on 2013-09-13.
+//  Copyright (c) 2013 Inkling. All rights reserved.
+//
+
+#import "SLIntegrationTest.h"
+
+@interface SLSwitchTest : SLIntegrationTest
+
+@end
+
+@implementation SLSwitchTest {
+    SLSwitch *_aSwitch;
+}
+
++ (NSString *)testCaseViewControllerClassName {
+    return @"SLSwitchTestViewController";
+}
+
+- (void)setUpTest
+{
+    [super setUpTest];
+    _aSwitch = [SLSwitch elementWithAccessibilityLabel:@"switch"];
+}
+
+- (void)setUpTestCaseWithSelector:(SEL)testCaseSelector
+{
+    [super setUpTestCaseWithSelector:testCaseSelector];
+    SLAssertTrue([UIAElement(_aSwitch) isValidAndVisible], @"Switch should be valid and visible");
+    SLAssertTrue([UIAElement(_aSwitch) isTappable], @"Switch should be tappable");
+    [_aSwitch setValue:ON];
+}
+
+- (void)testSLSwitchSetValue
+{
+    [_aSwitch setValue:OFF];
+    SLAssertTrue([[_aSwitch value] boolValue] == NO, @"Switch value was not set to OFF");
+    [_aSwitch setValue:ON];
+    SLAssertTrue([[_aSwitch value] boolValue] == YES, @"Switch value was not set to ON");
+}
+
+- (void)testSLSwitchIsOn
+{
+    [_aSwitch setValue:OFF];
+    SLAssertTrue([_aSwitch isOn] == NO, @"Switch should be OFF");
+    [_aSwitch setValue:ON];
+    SLAssertTrue([_aSwitch isOn] == YES, @"Switch should be ON");
+}
+
+- (void)testSLSwitchCanToggleWithTap {
+    BOOL value = [_aSwitch.value boolValue];
+    [_aSwitch tap];
+    SLAssertFalse(value == [_aSwitch.value boolValue], @"Value should have changed");
+    [_aSwitch tap];
+    SLAssertTrue(value == [_aSwitch.value boolValue], @"Value should have changed back");
+}
+
+@end

--- a/Integration Tests/Tests/SLSwitchTestViewController.m
+++ b/Integration Tests/Tests/SLSwitchTestViewController.m
@@ -1,0 +1,31 @@
+//
+//  SLSwitchTestViewController.m
+//  Subliminal
+//
+//  Created by Justin Mutter on 2013-09-13.
+//  Copyright (c) 2013 Inkling. All rights reserved.
+//
+
+#import "SLTestCaseViewController.h"
+
+@interface SLSwitchTestViewController : SLTestCaseViewController
+
+@end
+
+@interface SLSwitchTestViewController ()
+@property (weak, nonatomic) IBOutlet UISwitch *theSwitch;
+@end
+
+@implementation SLSwitchTestViewController
+
++ (NSString *)nibNameForTestCase:(SEL)testCase {
+    return @"SLSwitchTestViewController";
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.theSwitch.accessibilityLabel = @"switch";
+}
+
+@end

--- a/Integration Tests/Tests/SLSwitchTestViewController.xib
+++ b/Integration Tests/Tests/SLSwitchTestViewController.xib
@@ -1,30 +1,208 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4510" systemVersion="12E55" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
-    <dependencies>
-        <deployment defaultVersion="1296" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3742"/>
-    </dependencies>
-    <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SLSwitchTestViewController">
-            <connections>
-                <outlet property="theSwitch" destination="U4T-Tm-oxQ" id="Cah-Vz-zck"/>
-                <outlet property="view" destination="1" id="3"/>
-            </connections>
-        </placeholder>
-        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="1">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <subviews>
-                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="U4T-Tm-oxQ">
-                    <rect key="frame" x="136" y="108" width="51" height="31"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                </switch>
-            </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
-            <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
-        </view>
-    </objects>
-</document>
+<?xml version="1.0" encoding="UTF-8"?>
+<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
+	<data>
+		<int key="IBDocument.SystemTarget">1296</int>
+		<string key="IBDocument.SystemVersion">12E55</string>
+		<string key="IBDocument.InterfaceBuilderVersion">4510</string>
+		<string key="IBDocument.AppKitVersion">1187.39</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			<string key="NS.object.0">3742</string>
+		</object>
+		<array key="IBDocument.IntegratedClassDependencies">
+			<string>IBProxyObject</string>
+			<string>IBUISwitch</string>
+			<string>IBUIView</string>
+		</array>
+		<array key="IBDocument.PluginDependencies">
+			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+		</array>
+		<object class="NSMutableDictionary" key="IBDocument.Metadata">
+			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
+			<integer value="1" key="NS.object.0"/>
+		</object>
+		<array class="NSMutableArray" key="IBDocument.RootObjects" id="101314920">
+			<object class="IBProxyObject" id="668231280">
+				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBProxyObject" id="194204279">
+				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBUIView" id="287483895">
+				<reference key="NSNextResponder"/>
+				<int key="NSvFlags">1298</int>
+				<array class="NSMutableArray" key="NSSubviews">
+					<object class="IBUISwitch" id="160730020">
+						<reference key="NSNextResponder" ref="287483895"/>
+						<int key="NSvFlags">1316</int>
+						<object class="NSPSMatrix" key="NSFrameMatrix"/>
+						<string key="NSFrame">{{121, 108}, {94, 27}}</string>
+						<reference key="NSSuperview" ref="287483895"/>
+						<reference key="NSWindow"/>
+						<string key="NSHuggingPriority">{750, 750}</string>
+						<bool key="IBUIOpaque">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<bool key="IBUIOn">YES</bool>
+					</object>
+				</array>
+				<object class="NSPSMatrix" key="NSFrameMatrix"/>
+				<string key="NSFrame">{{0, 64}, {320, 504}}</string>
+				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView" ref="160730020"/>
+				<object class="NSColor" key="IBUIBackgroundColor">
+					<int key="NSColorSpace">3</int>
+					<bytes key="NSWhite">MQA</bytes>
+					<object class="NSColorSpace" key="NSCustomColorSpace">
+						<int key="NSID">2</int>
+					</object>
+				</object>
+				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
+				<object class="IBUISimulatedNavigationBarMetrics" key="IBUISimulatedTopBarMetrics">
+					<bool key="IBUIPrompted">NO</bool>
+				</object>
+				<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
+					<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
+					<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<array key="dict.sortedKeys">
+							<integer value="1"/>
+							<integer value="3"/>
+						</array>
+						<array key="dict.values">
+							<string>{320, 568}</string>
+							<string>{568, 320}</string>
+						</array>
+					</object>
+					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
+					<string key="IBUIDisplayName">Retina 4-inch Full Screen</string>
+					<int key="IBUIType">2</int>
+				</object>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+		</array>
+		<object class="IBObjectContainer" key="IBDocument.Objects">
+			<bool key="usesAutoincrementingIDs">NO</bool>
+			<array class="NSMutableArray" key="connectionRecords">
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">theSwitch</string>
+						<reference key="source" ref="668231280"/>
+						<reference key="destination" ref="160730020"/>
+					</object>
+					<string key="id">Cah-Vz-zck</string>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">view</string>
+						<reference key="source" ref="668231280"/>
+						<reference key="destination" ref="287483895"/>
+					</object>
+					<string key="id">3</string>
+				</object>
+			</array>
+			<object class="IBMutableOrderedSet" key="objectRecords">
+				<array key="orderedObjects">
+					<object class="IBObjectRecord">
+						<string key="id">0</string>
+						<array key="object" id="0"/>
+						<reference key="children" ref="101314920"/>
+						<nil key="parent"/>
+					</object>
+					<object class="IBObjectRecord">
+						<string key="id">-1</string>
+						<reference key="object" ref="668231280"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">File's Owner</string>
+					</object>
+					<object class="IBObjectRecord">
+						<string key="id">-2</string>
+						<reference key="object" ref="194204279"/>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<string key="id">1</string>
+						<reference key="object" ref="287483895"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="160730020"/>
+						</array>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<string key="id">U4T-Tm-oxQ</string>
+						<reference key="object" ref="160730020"/>
+						<reference key="parent" ref="287483895"/>
+					</object>
+				</array>
+			</object>
+			<dictionary class="NSMutableDictionary" key="flattenedProperties">
+				<string key="-1.CustomClassName">SLSwitchTestViewController</string>
+				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<boolean value="NO" key="-1.showNotes"/>
+				<string key="-2.CustomClassName">UIResponder</string>
+				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<boolean value="NO" key="-2.showNotes"/>
+				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<reference key="1.IBUserGuides" ref="0"/>
+				<boolean value="NO" key="1.showNotes"/>
+				<string key="U4T-Tm-oxQ.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<reference key="U4T-Tm-oxQ.IBUserGuides" ref="0"/>
+				<boolean value="NO" key="U4T-Tm-oxQ.showNotes"/>
+			</dictionary>
+			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
+			<nil key="activeLocalization"/>
+			<dictionary class="NSMutableDictionary" key="localizations"/>
+			<nil key="sourceID"/>
+		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<object class="IBPartialClassDescription">
+					<string key="className">SLSwitchTestViewController</string>
+					<string key="superclassName">SLTestCaseViewController</string>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">theSwitch</string>
+						<string key="NS.object.0">UISwitch</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">theSwitch</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0">
+							<string key="name">theSwitch</string>
+							<string key="candidateClassName">UISwitch</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/SLSwitchTestViewController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">SLTestCaseViewController</string>
+					<string key="superclassName">UIViewController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/SLTestCaseViewController.h</string>
+					</object>
+				</object>
+			</array>
+		</object>
+		<int key="IBDocument.localizationMode">0</int>
+		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
+		<bool key="IBDocument.previouslyAttemptedUpgradeToXcode5">YES</bool>
+		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
+			<real value="1296" key="NS.object.0"/>
+		</object>
+		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.InterfaceBuilder3</string>
+			<integer value="4600" key="NS.object.0"/>
+		</object>
+		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
+		<int key="IBDocument.defaultPropertyAccessControl">3</int>
+		<string key="IBCocoaTouchPluginVersion">3742</string>
+	</data>
+</archive>

--- a/Integration Tests/Tests/SLSwitchTestViewController.xib
+++ b/Integration Tests/Tests/SLSwitchTestViewController.xib
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4510" systemVersion="12E55" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+    <dependencies>
+        <deployment defaultVersion="1296" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3742"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SLSwitchTestViewController">
+            <connections>
+                <outlet property="theSwitch" destination="U4T-Tm-oxQ" id="Cah-Vz-zck"/>
+                <outlet property="view" destination="1" id="3"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="U4T-Tm-oxQ">
+                    <rect key="frame" x="136" y="108" width="51" height="31"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                </switch>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+        </view>
+    </objects>
+</document>

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLSwitch.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLSwitch.h
@@ -1,0 +1,20 @@
+//
+//  SLSwitch.h
+//  Subliminal
+//
+//  Created by Justin Mutter on 2013-09-13.
+//  Copyright (c) 2013 Inkling. All rights reserved.
+//
+
+#import <Subliminal/Subliminal.h>
+
+#define ON YES
+#define OFF NO
+
+@interface SLSwitch : SLButton
+
+@property (readonly,getter=isOn) BOOL on;
+
+- (void)setValue:(BOOL)value;
+
+@end

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLSwitch.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLSwitch.h
@@ -9,7 +9,7 @@
 #import "SLButton.h"
 
 /**
- `SLSwitch` will match against any `UIButton` object, but provides extra functionality for instances of `UISwitch`.
+ `SLSwitch` matches against instances of `UISwitch`
  
   Tappipng an `SLSwitch` will toggle its value, which can be queried with the `on` property, or the switch may be set to a specific value.
  */
@@ -17,6 +17,8 @@
 
 /**
  The boolean value of the switch.
+ 
+ `setOn:` will set the value of the switch regardless of the current state, as opposed to tapping which will toggle it.
  */
 @property (nonatomic, getter=isOn) BOOL on;
 

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLSwitch.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLSwitch.h
@@ -8,26 +8,16 @@
 
 #import "SLButton.h"
 
-#define ON YES
-#define OFF NO
-
 /**
  `SLSwitch` will match against any `UIButton` object, but provides extra functionality for instances of `UISwitch`.
  
-  Tappipng an `SLSwitch` will toggle it's value, which can be querried with the `on` property, or the switch may be set to a specific value.
+  Tappipng an `SLSwitch` will toggle its value, which can be queried with the `on` property, or the switch may be set to a specific value.
  */
 @interface SLSwitch : SLButton
 
 /**
  The boolean value of the switch.
  */
-@property (readonly,getter=isOn) BOOL on;
-
-/**
- Sets the value of the switch, regardless of it's current value.
-
- @param value The boolean value to set the switch to.
-*/
-- (void)setValue:(BOOL)value;
+@property (nonatomic, getter=isOn) BOOL on;
 
 @end

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLSwitch.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLSwitch.h
@@ -6,15 +6,28 @@
 //  Copyright (c) 2013 Inkling. All rights reserved.
 //
 
-#import <Subliminal/Subliminal.h>
+#import "SLButton.h"
 
 #define ON YES
 #define OFF NO
 
+/**
+ `SLSwitch` will match against any `UIButton` object, but provides extra functionality for instances of `UISwitch`.
+ 
+  Tappipng an `SLSwitch` will toggle it's value, which can be querried with the `on` property, or the switch may be set to a specific value.
+ */
 @interface SLSwitch : SLButton
 
+/**
+ The boolean value of the switch.
+ */
 @property (readonly,getter=isOn) BOOL on;
 
+/**
+ Sets the value of the switch, regardless of it's current value.
+
+ @param value The boolean value to set the switch to.
+*/
 - (void)setValue:(BOOL)value;
 
 @end

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLSwitch.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLSwitch.m
@@ -11,14 +11,18 @@
 
 @implementation SLSwitch
 
+- (BOOL)matchesObject:(NSObject *)object {
+    return ([super matchesObject:object] && [object isKindOfClass:[UISwitch class]]);
+}
+
 - (BOOL)isOn
 {
     return [[self value] boolValue];
 }
 
-- (void)setValue:(BOOL)value
+- (void)setOn:(BOOL)on
 {
-    NSString *valueString = value ? @"true" : @"false";
+    NSString *valueString = on ? @"true" : @"false";
     [self waitUntilTappable:NO thenSendMessage:@"setValue(%@)", valueString];
 }
 

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLSwitch.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLSwitch.m
@@ -1,0 +1,25 @@
+//
+//  SLSwitch.m
+//  Subliminal
+//
+//  Created by Justin Mutter on 2013-09-13.
+//  Copyright (c) 2013 Inkling. All rights reserved.
+//
+
+#import "SLSwitch.h"
+#import "SLUIAElement+Subclassing.h"
+
+@implementation SLSwitch
+
+- (BOOL)isOn
+{
+    return [[self value] boolValue];
+}
+
+- (void)setValue:(BOOL)value
+{
+    NSString *valueString = value ? @"true" : @"false";
+    [self waitUntilTappable:NO thenSendMessage:@"setValue(%@)", valueString];
+}
+
+@end

--- a/Sources/Subliminal.h
+++ b/Sources/Subliminal.h
@@ -34,6 +34,7 @@
 #import "SLKeyboard.h"
 #import "SLPopover.h"
 #import "SLStatusBar.h"
+#import "SLSwitch.h"
 #import "SLTextField.h"
 #import "SLTextView.h"
 #import "SLWebView.h"

--- a/Subliminal.xcodeproj/project.pbxproj
+++ b/Subliminal.xcodeproj/project.pbxproj
@@ -31,6 +31,11 @@
 		0696BA5916E013D600DD70CF /* SLElementDraggingTestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0696BA5616E013D600DD70CF /* SLElementDraggingTestViewController.m */; };
 		0696BA5A16E013D600DD70CF /* SLElementDraggingTestViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0696BA5716E013D600DD70CF /* SLElementDraggingTestViewController.xib */; };
 		06F49B6117DA946400143D42 /* chisqr.c in Sources */ = {isa = PBXBuildFile; fileRef = 06F49B6017DA946400143D42 /* chisqr.c */; };
+		2C903BC017F525E700555317 /* SLSwitchTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C903BBD17F525E700555317 /* SLSwitchTest.m */; };
+		2C903BC117F525E700555317 /* SLSwitchTestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C903BBE17F525E700555317 /* SLSwitchTestViewController.m */; };
+		2C903BC217F525E700555317 /* SLSwitchTestViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2C903BBF17F525E700555317 /* SLSwitchTestViewController.xib */; };
+		2CE9AA4C17E3A747007EF0B5 /* SLSwitch.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CE9AA4A17E3A747007EF0B5 /* SLSwitch.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2CE9AA4D17E3A747007EF0B5 /* SLSwitch.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CE9AA4B17E3A747007EF0B5 /* SLSwitch.m */; };
 		CA75E78216697A1200D57E92 /* SLDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = CA75E78016697A1200D57E92 /* SLDevice.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA75E78516697C0000D57E92 /* SLDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = CA75E78116697A1200D57E92 /* SLDevice.m */; };
 		CAC388051641CD7500F995F9 /* SLStringUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = CAC388031641CD7500F995F9 /* SLStringUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -243,6 +248,11 @@
 		0696BA5716E013D600DD70CF /* SLElementDraggingTestViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SLElementDraggingTestViewController.xib; sourceTree = "<group>"; };
 		06F49B6017DA946400143D42 /* chisqr.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chisqr.c; sourceTree = "<group>"; };
 		06F49B6517DA947000143D42 /* chisqr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = chisqr.h; sourceTree = "<group>"; };
+		2C903BBD17F525E700555317 /* SLSwitchTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLSwitchTest.m; sourceTree = "<group>"; };
+		2C903BBE17F525E700555317 /* SLSwitchTestViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLSwitchTestViewController.m; sourceTree = "<group>"; };
+		2C903BBF17F525E700555317 /* SLSwitchTestViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SLSwitchTestViewController.xib; sourceTree = "<group>"; };
+		2CE9AA4A17E3A747007EF0B5 /* SLSwitch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLSwitch.h; sourceTree = "<group>"; };
+		2CE9AA4B17E3A747007EF0B5 /* SLSwitch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLSwitch.m; sourceTree = "<group>"; };
 		CA75E78016697A1200D57E92 /* SLDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLDevice.h; sourceTree = "<group>"; };
 		CA75E78116697A1200D57E92 /* SLDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLDevice.m; sourceTree = "<group>"; };
 		CAC388031641CD7500F995F9 /* SLStringUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLStringUtilities.h; sourceTree = "<group>"; };
@@ -448,6 +458,16 @@
 				F0CC7596173B092300E8F94A /* Dragging */,
 			);
 			name = "SLElement Gestures and Actions Tests";
+			sourceTree = "<group>";
+		};
+		2C903BB917F525C900555317 /* SLSwitch Tests */ = {
+			isa = PBXGroup;
+			children = (
+				2C903BBD17F525E700555317 /* SLSwitchTest.m */,
+				2C903BBE17F525E700555317 /* SLSwitchTestViewController.m */,
+				2C903BBF17F525E700555317 /* SLSwitchTestViewController.xib */,
+			);
+			name = "SLSwitch Tests";
 			sourceTree = "<group>";
 		};
 		CAC388011641CD4800F995F9 /* Internal */ = {
@@ -673,6 +693,8 @@
 				F0C07A371703F95B00C93F93 /* SLAlert.m */,
 				F0C07A451703FEF600C93F93 /* SLButton.h */,
 				F0C07A461703FEF600C93F93 /* SLButton.m */,
+				2CE9AA4A17E3A747007EF0B5 /* SLSwitch.h */,
+				2CE9AA4B17E3A747007EF0B5 /* SLSwitch.m */,
 				F0C07A511704011300C93F93 /* SLKeyboard.h */,
 				F0C07A521704011300C93F93 /* SLKeyboard.m */,
 				F00800CC174C1C64001927AC /* SLPopover.h */,
@@ -796,6 +818,7 @@
 				F089F9DC1745FB3800DF1F25 /* SLKeyboard Tests */,
 				F00800D3174C2871001927AC /* SLPopover Tests */,
 				F089F9FD1746B1D200DF1F25 /* SLStaticElement Tests */,
+				2C903BB917F525C900555317 /* SLSwitch Tests */,
 				F01EBC951701150E00FF6A7C /* SLTextField Tests */,
 				F0A3F63917A716FC007529C3 /* SLTextView Tests */,
 				F013798E16D0843B009BAF22 /* SLTerminal Tests */,
@@ -899,6 +922,7 @@
 				F05C4F90171406EF00A381BC /* SLTerminal+ConvenienceFunctions.h in Headers */,
 				F05C51E5171C8AE000A381BC /* SLMainThreadRef.h in Headers */,
 				F0A04E1D1749F70F002C7520 /* SLElement.h in Headers */,
+				2CE9AA4C17E3A747007EF0B5 /* SLSwitch.h in Headers */,
 				F089F98617445D9A00DF1F25 /* SLStaticElement.h in Headers */,
 				F00800CE174C1C64001927AC /* SLPopover.h in Headers */,
 				F043469F175ACE3A00D91F7F /* NSObject+SLAccessibilityDescription.h in Headers */,
@@ -1072,6 +1096,7 @@
 				F0A3F63F17A7172E007529C3 /* SLTextViewTestViewController.xib in Resources */,
 				F0A3F64117A73198007529C3 /* SLWebTextView.html in Resources */,
 				DB2627E117B96974009DA3A6 /* SLStatusBarTestViewController.xib in Resources */,
+				2C903BC217F525E700555317 /* SLSwitchTestViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1119,6 +1144,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2CE9AA4D17E3A747007EF0B5 /* SLSwitch.m in Sources */,
 				F0695DE4160138DF000B05D0 /* SLUIAElement.m in Sources */,
 				F0695DE5160138DF000B05D0 /* SLLogger.m in Sources */,
 				F0695DE7160138DF000B05D0 /* SLTerminal.m in Sources */,
@@ -1151,6 +1177,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2C903BC017F525E700555317 /* SLSwitchTest.m in Sources */,
 				F0AC80A016BB299500C5D5C0 /* main.m in Sources */,
 				F0AC80A416BB299500C5D5C0 /* SLIntegrationTestsAppDelegate.m in Sources */,
 				F0AC80BD16BB50FF00C5D5C0 /* SLTestsViewController.m in Sources */,
@@ -1169,6 +1196,7 @@
 				F0AE4C8E16F7F92D00B2BB2B /* SLElementStateTestViewController.m in Sources */,
 				F07DA32D16E43AD3004C2282 /* SLAlertTest.m in Sources */,
 				F07DA32E16E43AD3004C2282 /* SLAlertTestViewController.m in Sources */,
+				2C903BC117F525E700555317 /* SLSwitchTestViewController.m in Sources */,
 				F01EBC9B170115B100FF6A7C /* SLTextFieldTest.m in Sources */,
 				F01EBC9C170115B100FF6A7C /* SLTextFieldTestViewController.m in Sources */,
 				F077D70D16D9D77900908FF5 /* SLElementVisibilityTest.m in Sources */,


### PR DESCRIPTION
This adds an `SLSwitch` class which enables wraps `UIASwitch`'s `setValue` method, and provides a property to access the current value of the switch as a bool instead of a string.
