### PR TITLE
Ensure that the web view child element matching test case's view loads b...

### DIFF
--- a/Integration Tests/Tests/SLElementMatchingTest.m
+++ b/Integration Tests/Tests/SLElementMatchingTest.m
@@ -42,6 +42,9 @@
         SLAskApp(removeFooButtonFromSuperview);
     } else if (testCaseSelector == @selector(testElementWithAccessibilityLabelValueTraits)) {
         SLAskApp(applyUniqueTraitToFooButton);
+    } else if (testCaseSelector == @selector(testMatchingWebViewChildElements_iPhone)) {
+        SLAssertTrueWithTimeout(SLAskAppYesNo(webViewDidFinishLoad), 5.0,
+                                @"Webview did not load test HTML.");
     }
 }
 
@@ -52,9 +55,6 @@
         SLAskApp(hidePopover);
     } else if (testCaseSelector == @selector(testMatchingActionSheetButtons)) {
         SLAskApp(hideActionSheet);
-    } else if (testCaseSelector == @selector(testMatchingWebViewChildElements_iPhone)) {
-        SLAssertTrueWithTimeout(SLAskAppYesNo(webViewDidFinishLoad), 5.0,
-                                @"Webview did not load test HTML.");
     }
     [super tearDownTestCaseWithSelector:testCaseSelector];
 }


### PR DESCRIPTION
...efore the test case _starts_.

The assertion was mistakenly placed in `tearDownTestCaseWithSelector:` rather than
the set-up method.
