### PR TITLE
Allows various text views to handle "tap-hold" characters (fixes #91)

### DIFF
--- a/Integration Tests/Tests/SLTextFieldTest.m
+++ b/Integration Tests/Tests/SLTextFieldTest.m
@@ -40,6 +40,7 @@
     [super setUpTestCaseWithSelector:testSelector];
 
     if (testSelector == @selector(testSetText) ||
+        testSelector == @selector(testSetTextCanHandleTapHoldCharacters) ||
         testSelector == @selector(testSetTextClearsCurrentText) ||
         testSelector == @selector(testSetTextWhenFieldClearsOnBeginEditing) ||
         testSelector == @selector(testGetText) ||
@@ -63,6 +64,12 @@
 
 - (void)testSetText {
     NSString *const expectedText = @"foo";
+    SLAssertNoThrow([UIAElement(_textField) setText:expectedText], @"Should not have thrown.");
+    SLAssertTrue([SLAskApp(text) isEqualToString:expectedText], @"Text was not set to expected value.");
+}
+
+- (void)testSetTextCanHandleTapHoldCharacters {
+    NSString *const expectedText = @"foo’s a difficult string to type!";
     SLAssertNoThrow([UIAElement(_textField) setText:expectedText], @"Should not have thrown.");
     SLAssertTrue([SLAskApp(text) isEqualToString:expectedText], @"Text was not set to expected value.");
 }

--- a/Integration Tests/Tests/SLTextFieldTestViewController.m
+++ b/Integration Tests/Tests/SLTextFieldTestViewController.m
@@ -39,6 +39,7 @@
     UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
     const CGRect kTextFieldFrame = (CGRect){CGPointZero, CGSizeMake(100.0f, 30.0f)};
     if (testCase == @selector(testSetText) ||
+        testCase == @selector(testSetTextCanHandleTapHoldCharacters) ||
         testCase == @selector(testSetTextClearsCurrentText) ||
         testCase == @selector(testSetTextWhenFieldClearsOnBeginEditing) ||
         testCase == @selector(testGetText) ||
@@ -141,6 +142,7 @@
 - (NSString *)text {
     NSString *text;
     if (self.testCase == @selector(testSetText) ||
+        self.testCase == @selector(testSetTextCanHandleTapHoldCharacters) ||
         self.testCase == @selector(testSetTextClearsCurrentText) ||
         self.testCase == @selector(testSetTextWhenFieldClearsOnBeginEditing) ||
         self.testCase == @selector(testGetText) ||

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLKeyboard+Internal.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLKeyboard+Internal.h
@@ -1,0 +1,31 @@
+//
+//  SLKeyboard+Internal.h
+//  Subliminal
+//
+//  Created by Aaron Golden on 10/21/13.
+//  Copyright (c) 2013 Inkling. All rights reserved.
+//
+
+#import "SLKeyboard.h"
+
+@class SLUIAElement;
+
+@interface SLKeyboard (Internal)
+
+/**
+ Uses -[SLKeyboard typeString:] to tap the keys of the input string on the
+ receiver.  Unlike -[SLKeyboard typeString:], this method will not throw an
+ exception if the input string contains characters that can be accessed on
+ the receiver only through a tap-hold gesture.  Instead, this method will
+ send the setValue JavaScript message to the input element as a "fallback"
+ procedure.
+
+ @param string The string to be typed on the keyboard or set as the value for
+ element.
+ @param element The user interface element on which the setValue JavaScript
+ method will be called if the internal call to -[SLKeyboard typeString:]
+ throws an exception.
+ */
+ - (void)typeString:(NSString *)string withSetValueFallbackUsingElement:(SLUIAElement *)element;
+
+@end

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLKeyboard+Internal.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLKeyboard+Internal.m
@@ -1,0 +1,26 @@
+//
+//  SLKeyboard+Internal.m
+//  Subliminal
+//
+//  Created by Aaron Golden on 10/21/13.
+//  Copyright (c) 2013 Inkling. All rights reserved.
+//
+
+#import "SLKeyboard+Internal.h"
+
+#import "SLUIAElement+Subclassing.h"
+#import "SLLogger.h"
+#import "SLStringUtilities.h"
+
+@implementation SLKeyboard (Internal)
+
+- (void)typeString:(NSString *)string withSetValueFallbackUsingElement:(SLUIAElement *)element {
+    @try {
+        [self typeString:string];
+    } @catch (id exception) {
+        [[SLLogger sharedLogger] logWarning:[NSString stringWithFormat:@"-[SLKeyboard typeString:] will fall back on UIAElement.setValue due to an exception in UIAKeyboard.typeString: %@", exception]];
+        [element waitUntilTappable:YES thenSendMessage:@"setValue('%@')", [string slStringByEscapingForJavaScriptLiteral]];
+    }
+}
+
+@end

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLKeyboard.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLKeyboard.h
@@ -47,6 +47,12 @@
  as necessary to make the corresponding keys visible.
 
  @param string The string to be typed on the keyboard.
+
+ @bug This method throws an exception if string contains any characters
+ that can be accessed only through a tap-hold gesture, for example
+ “smart-quotes.”  Note that SLTextField, SLTextView, and related classes
+ work around this bug internally when their text contents are set with
+ the -setText: method.
  */
 - (void)typeString:(NSString *)string;
 

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLTextField.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLTextField.m
@@ -22,7 +22,7 @@
 
 #import "SLTextField.h"
 #import "SLUIAElement+Subclassing.h"
-#import "SLKeyboard.h"
+#import "SLKeyboard+Internal.h"
 
 @implementation SLTextField
 
@@ -40,7 +40,7 @@
     // Clear any current text before typing the new text.
     [self waitUntilTappable:YES thenSendMessage:@"setValue('')"];
     
-    [[SLKeyboard keyboard] typeString:text];
+    [[SLKeyboard keyboard] typeString:text withSetValueFallbackUsingElement:self];
 }
 
 - (BOOL)matchesObject:(NSObject *)object {
@@ -109,7 +109,7 @@
         [[SLKeyboardKey elementWithAccessibilityLabel:@"Delete"] tap];
     }
 
-    [[SLKeyboard keyboard] typeString:text];
+    [[SLKeyboard keyboard] typeString:text withSetValueFallbackUsingElement:self];
 }
 
 @end

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLTextView.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLTextView.m
@@ -8,7 +8,7 @@
 
 #import "SLTextView.h"
 #import "SLUIAElement+Subclassing.h"
-#import "SLKeyboard.h"
+#import "SLKeyboard+Internal.h"
 
 @implementation SLTextView
 
@@ -26,7 +26,7 @@
     // Clear any current text before typing the new text.
     [self waitUntilTappable:YES thenSendMessage:@"setValue('')"];
     
-    [[SLKeyboard keyboard] typeString:text];
+    [[SLKeyboard keyboard] typeString:text withSetValueFallbackUsingElement:self];
 }
 
 - (BOOL)matchesObject:(NSObject *)object {
@@ -70,7 +70,7 @@
         [[SLKeyboardKey elementWithAccessibilityLabel:@"Delete"] tap];
     }
 
-    [[SLKeyboard keyboard] typeString:text];
+    [[SLKeyboard keyboard] typeString:text withSetValueFallbackUsingElement:self];
 }
 
 @end

--- a/Subliminal.xcodeproj/project.pbxproj
+++ b/Subliminal.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		0640035B178FDE7800479173 /* SLElementTouchAndHoldTestViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 06400359178FDE7800479173 /* SLElementTouchAndHoldTestViewController.xib */; };
 		064B6F55173B13E9004AB1BF /* SLElementVisibilityTestCoveredByClearRegion.xib in Resources */ = {isa = PBXBuildFile; fileRef = 064B6F54173B13E9004AB1BF /* SLElementVisibilityTestCoveredByClearRegion.xib */; };
 		064B6FC7173DCE9A004AB1BF /* SLElementVisibilityWithSubviews.xib in Resources */ = {isa = PBXBuildFile; fileRef = 064B6FC6173DCE9A004AB1BF /* SLElementVisibilityWithSubviews.xib */; };
+		0657C0E2181528B8007E72DF /* SLKeyboard+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0657C0E0181528B6007E72DF /* SLKeyboard+Internal.h */; };
+		0657C0E3181528B8007E72DF /* SLKeyboard+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 0657C0E1181528B7007E72DF /* SLKeyboard+Internal.m */; };
 		068D3E4D16DE9008004E7E28 /* SLTableViewChildElementMatchingTestViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 068D3E4C16DE9008004E7E28 /* SLTableViewChildElementMatchingTestViewController.xib */; };
 		06953E3F178FDA7100B3D1B7 /* SLElementTouchAndHoldTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 06953E3E178FDA7100B3D1B7 /* SLElementTouchAndHoldTest.m */; };
 		0696BA5816E013D600DD70CF /* SLElementDraggingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0696BA5516E013D600DD70CF /* SLElementDraggingTest.m */; };
@@ -245,6 +247,8 @@
 		06400359178FDE7800479173 /* SLElementTouchAndHoldTestViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SLElementTouchAndHoldTestViewController.xib; sourceTree = "<group>"; };
 		064B6F54173B13E9004AB1BF /* SLElementVisibilityTestCoveredByClearRegion.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SLElementVisibilityTestCoveredByClearRegion.xib; sourceTree = "<group>"; };
 		064B6FC6173DCE9A004AB1BF /* SLElementVisibilityWithSubviews.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SLElementVisibilityWithSubviews.xib; sourceTree = "<group>"; };
+		0657C0E0181528B6007E72DF /* SLKeyboard+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SLKeyboard+Internal.h"; sourceTree = "<group>"; };
+		0657C0E1181528B7007E72DF /* SLKeyboard+Internal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SLKeyboard+Internal.m"; sourceTree = "<group>"; };
 		068D3E4C16DE9008004E7E28 /* SLTableViewChildElementMatchingTestViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SLTableViewChildElementMatchingTestViewController.xib; sourceTree = "<group>"; };
 		06953E3E178FDA7100B3D1B7 /* SLElementTouchAndHoldTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLElementTouchAndHoldTest.m; sourceTree = "<group>"; };
 		0696BA5516E013D600DD70CF /* SLElementDraggingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLElementDraggingTest.m; sourceTree = "<group>"; };
@@ -716,6 +720,8 @@
 				2CE9AA4B17E3A747007EF0B5 /* SLSwitch.m */,
 				F0C07A511704011300C93F93 /* SLKeyboard.h */,
 				F0C07A521704011300C93F93 /* SLKeyboard.m */,
+				0657C0E0181528B6007E72DF /* SLKeyboard+Internal.h */,
+				0657C0E1181528B7007E72DF /* SLKeyboard+Internal.m */,
 				F00800CC174C1C64001927AC /* SLPopover.h */,
 				F00800CD174C1C64001927AC /* SLPopover.m */,
 				F0C07A491704002100C93F93 /* SLTextField.h */,
@@ -951,6 +957,7 @@
 				F04346A7175AD10200D91F7F /* NSObject+SLVisibility.h in Headers */,
 				F0A3F63417A715AE007529C3 /* SLTextView.h in Headers */,
 				DB501DC917B9669A001658CB /* SLStatusBar.h in Headers */,
+				0657C0E2181528B8007E72DF /* SLKeyboard+Internal.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1192,6 +1199,7 @@
 				F04346A8175AD10200D91F7F /* NSObject+SLVisibility.m in Sources */,
 				F0A3F63517A715AE007529C3 /* SLTextView.m in Sources */,
 				DB501DCA17B9669A001658CB /* SLStatusBar.m in Sources */,
+				0657C0E3181528B8007E72DF /* SLKeyboard+Internal.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Adds an internal variant of SLKeyboard's typeString method,
which can fall back on the JavaScript setValue method if
the normal type string mechanism throws an exception.

Causes Subliminal UI element classes to use the new method
when appropriate.
