### PR TITLE
Add NS_FORMAT_FUNCTION declarations to SLComposeString and SLComposeStringV.

### DIFF
--- a/Sources/Classes/Internal/Terminal/SLStringUtilities.h
+++ b/Sources/Classes/Internal/Terminal/SLStringUtilities.h
@@ -58,7 +58,7 @@
  arguments are substituted (optionally prefixed by a leading string) if `format`
  is non-`nil`; otherwise, the empty string.
  */
-extern NSString *SLComposeString(NSString *leadingString, NSString *format, ...);
+extern NSString *SLComposeString(NSString *leadingString, NSString *format, ...) NS_FORMAT_FUNCTION(2,3);
 
 /**
  `SLComposeStringv` composes a format string and arguments for substitution
@@ -80,4 +80,4 @@ extern NSString *SLComposeString(NSString *leadingString, NSString *format, ...)
  arguments are substituted (optionally prefixed by a leading string) if `format` 
  is non-`nil`; otherwise, the empty string.
  */
-extern NSString *SLComposeStringv(NSString *leadingString, NSString *format, va_list args);
+extern NSString *SLComposeStringv(NSString *leadingString, NSString *format, va_list args) NS_FORMAT_FUNCTION(2,0);


### PR DESCRIPTION
This means that we get warned if the arguments do not match the
format specifiers in the failure descriptions for SLAssert*.
