### PR TITLE
Pass "numTestsExpected" to logTestingFinish

### DIFF
--- a/Sources/Classes/Logging/SLLogger.h
+++ b/Sources/Classes/Logging/SLLogger.h
@@ -221,10 +221,12 @@ void SLLogAsync(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
  This method is called after all tests have run.
  
  @param numTestsExecuted The number of tests that were executed.
- @param numTestsFailed Of `numTestsExecuted`, the number of tests that failed 
+ @param numTestsExpected The number of tests that should have been executed.
+ @param numTestsFailed Of `numTestsExecuted`, the number of tests that failed
  (by throwing an exception in set-up, tear-down, or a test case).
  */
 - (void)logTestingFinishWithNumTestsExecuted:(NSUInteger)numTestsExecuted
+                            numTestsExpected:(NSUInteger)numTestsExpected
                               numTestsFailed:(NSUInteger)numTestsFailed;
 
 @end

--- a/Sources/Classes/Logging/SLLogger.m
+++ b/Sources/Classes/Logging/SLLogger.m
@@ -151,10 +151,13 @@ void SLLogAsync(NSString *format, ...) {
 }
 
 - (void)logTestingFinishWithNumTestsExecuted:(NSUInteger)numTestsExecuted
+                            numTestsExpected:(NSUInteger)numTestsExpected
                               numTestsFailed:(NSUInteger)numTestsFailed {
-    [self logMessage:[NSString stringWithFormat:@"Testing finished: executed %u test%@, with %u failure%@.",
-                                                numTestsExecuted, (numTestsExecuted == 1 ? @"" : @"s"),
-                                                numTestsFailed, (numTestsFailed == 1 ? @"" : @"s")]];
+    [self logMessage:[NSString stringWithFormat:@"Testing %@: executed %u test%@, of %u expected, with %u failure%@.",
+                      (numTestsExecuted == numTestsExpected) ? @"finished" : @"did not finish",
+                      numTestsExecuted, (numTestsExecuted == 1 ? @"" : @"s"),
+                      numTestsExpected,
+                      numTestsFailed, (numTestsFailed == 1 ? @"" : @"s")]];
 }
 
 @end

--- a/Sources/Classes/SLTestController.m
+++ b/Sources/Classes/SLTestController.m
@@ -359,6 +359,7 @@ u_int32_t random_uniform(u_int32_t upperBound) {
 
 - (void)_finishTesting {
     [[SLLogger sharedLogger] logTestingFinishWithNumTestsExecuted:_numTestsExecuted
+                                                 numTestsExpected:_testsToRun.count
                                                    numTestsFailed:_numTestsFailed];
 
     if (_numTestsFailed > 0) {

--- a/Unit Tests/SLTestControllerTests.m
+++ b/Unit Tests/SLTestControllerTests.m
@@ -167,7 +167,7 @@ static const NSUInteger kNumSeedTrials = 100;
     [[[failingTestMock expect] andThrow:exception] testOne];
 
     // Expect testing to finish with a failure
-    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:[tests count] numTestsFailed:1];
+    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:[tests count] numTestsExpected:[tests count] numTestsFailed:1];
 
     // Expect the seed to be logged, and capture it
     __block unsigned int seed = 0;
@@ -217,7 +217,7 @@ static const NSUInteger kNumSeedTrials = 100;
 
     // Here we're hardcoding the number of tests that `runTestsUsingSeed:testsRanInSameOrder:` uses
     // --this will just have to be updated if that method changes
-    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:3 numTestsFailed:0];
+    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:3 numTestsExpected:3 numTestsFailed:0];
 
     // warning at end
     NSString *const seedWarning = @"Tests were run in a predetermined order.";
@@ -427,7 +427,7 @@ static const NSUInteger kNumSeedTrials = 100;
                                                                  failed:[OCMArg anyPointer]
                                                      failedUnexpectedly:[OCMArg anyPointer]];
 
-    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:1 numTestsFailed:0];
+    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:1 numTestsExpected:1 numTestsFailed:0];
     
     // warning at end
     [[_loggerMock expect] logWarning:@"This was a focused run. Fewer test cases may have run than normal."];

--- a/Unit Tests/SLTestTests.m
+++ b/Unit Tests/SLTestTests.m
@@ -455,7 +455,7 @@
     [[_loggerMock expect] logTestFinish:NSStringFromClass(testClass)
                            withNumCasesExecuted:3 numCasesFailed:0 numCasesFailedUnexpectedly:0];
 
-    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:1 numTestsFailed:0];
+    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:1 numTestsExpected:1 numTestsFailed:0];
 
     // *** End expected test run
     
@@ -554,7 +554,7 @@
     [[_loggerMock expect] logTestAbort:NSStringFromClass(failingTestClass)];
 
     // ...and the test controller logs testing as finishing with one test executed, one test failing.
-    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:1 numTestsFailed:1];
+    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:1  numTestsExpected:1 numTestsFailed:1];
 
     // *** End expected test run
 
@@ -680,7 +680,7 @@
                           withNumCasesExecuted:3 numCasesFailed:1 numCasesFailedUnexpectedly:0];
 
     // ...and the test controller logs testing as finishing with one test executed, one test failing.
-    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:1 numTestsFailed:1];
+    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:1 numTestsExpected:1 numTestsFailed:1];
 
     // *** End expected test run
 
@@ -859,7 +859,7 @@
                           withNumCasesExecuted:3 numCasesFailed:0 numCasesFailedUnexpectedly:0];
 
     // ...and the test controller logs testing as finishing with one test executed, no tests failing.
-    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:1 numTestsFailed:0];
+    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:1 numTestsExpected:1 numTestsFailed:0];
 
     // *** End expected test run
 
@@ -904,7 +904,7 @@
              numCasesFailedUnexpectedly:(failWithAssertionException ? 0 : 1)];
 
     // ...and the test controller logs testing as finishing with one test executed, one test failing.
-    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:1 numTestsFailed:1];
+    [[_loggerMock expect] logTestingFinishWithNumTestsExecuted:1 numTestsExpected:1 numTestsFailed:1];
 
     // *** End expected test run
 


### PR DESCRIPTION
Adds a new parameter to the logTestingFinished method for the
number of tests that were expected to run, and causes the method
to log "Testing did not finish..." if the number of tests that
executed is not equal to the number of tests that were expected.
