### PR TITLE
Increase the interval `+[SLPopover dismiss]` waits before returning.

### DIFF
--- a/Sources/Classes/UIAutomation/User Interface Elements/SLPopover.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLPopover.m
@@ -40,7 +40,7 @@
     [self waitUntilTappable:NO thenSendMessage:@"dismiss()"];
 
     // wait for the dismissal animation to finish
-    [NSThread sleepForTimeInterval:0.3];
+    [NSThread sleepForTimeInterval:0.5];
 }
 
 @end


### PR DESCRIPTION
To ensure that the popover is invisible, in response to another failure on Travis:
https://travis-ci.org/inkling/Subliminal/jobs/16987504.
