### PR TITLE
Get the path for the deepest matching element

### DIFF
--- a/Sources/Classes/Internal/SLAccessibilityPath.m
+++ b/Sources/Classes/Internal/SLAccessibilityPath.m
@@ -220,10 +220,6 @@
 }
 
 - (NSArray *)rawAccessibilityPathToElement:(SLElement *)element favoringSubviews:(BOOL)favoringSubviews {
-    if ([element matchesObject:self]) {
-        return [NSArray arrayWithObject:self];
-    }
-
     for (NSObject *child in [self slChildAccessibilityElementsFavoringSubviews:favoringSubviews]) {
         NSArray *path = [child rawAccessibilityPathToElement:element favoringSubviews:favoringSubviews];
         if (path) {
@@ -231,6 +227,10 @@
             [pathWithSelf insertObject:self atIndex:0];
             return pathWithSelf;
         }
+    }
+
+    if ([element matchesObject:self]) {
+        return [NSArray arrayWithObject:self];
     }
     return nil;
 }


### PR DESCRIPTION
We usually want to grab the path for the deepest (leaf) matching object in the tree; this is especially true in iOS 7 since Apple changed the accessibility hierarchy and inserted intermediate views or accessibility elements in between.

Let’s modify `-rawAccessibilityPathToElement:favoringSubviews:` to search for the deepest matching object instead of return the first the method encounters.
