### PR TITLE
Guard against nil case for accessibilityElementAtIndex:

### DIFF
--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
@@ -109,6 +109,13 @@
         if (count != NSNotFound && count > 0) {
             for (NSInteger i = 0; i < count; i++) {
                 id element = [self accessibilityElementAtIndex:i];
+                if (!element) {
+                    dispatch_async([[SLLogger sharedLogger] loggingQueue], ^{
+                        NSString *message = [NSString stringWithFormat:@"accessibilityElementAtIndex: %d is nil for %@", i, self];
+                        [[SLLogger sharedLogger] logWarning:message];
+                    });
+                    continue;
+                }
                 (void)[element accessibilityLabel];
                 if (element != [self accessibilityElementAtIndex:i]) {
                     // Protect against tests entering an infinite loop,


### PR DESCRIPTION
If the accessibility protocol methods are not properly implemented (as
in custom controls for example), we might have a case where
accessibilityElementAtIndex: will return nil. This causes a crash in
slChildAccessibilityElementsFavoringSubviews: with a nil insertion
into an array. The fix is to guard against adding nil element to the
children array.

This is a proposed solution, if it is agreeable with your coding style. I tried to do the logWarning: inline but it caused Instruments to hang, but adding a dispatch_async solved it...

This problem was actually biting us, and it caused Instruments to end abruptly with an unhandled exception. Avoiding this nil insertion has cleared the way for our tests. (and also now we know we have some clean-up work to do on our custom controls regarding our accessibility implementation!)
