### PR TITLE
Add test tagging support to SLTest

### DIFF
--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -54,6 +54,19 @@
 + (NSSet *)allTests;
 
 /**
+ Returns tests linked against the current target which contains a tag matching at least one tag specified in `tags`
+
+ This method will include a test in the returned set if any of the specified tags in the `tags` parameter match at least one of the tags in `+[SLTest tags]`. This is essentially a set union operation (i.e. specifying multiple tags will return all tests that match any of them).
+
+ This method may be useful to specify a certain set of tests in your app that pertain to a specific funtionality or to divide up your tests into separate test suites.
+
+ @param tags An array of tags to match against the tags specified in `+[SLTest tags]`
+
+ @return All tests (`SLTest` subclasses) linked against the current target which contains a tag matching at least one tag specified in `tags`
+ */
++ (NSSet *)testsWithTags:(NSArray *)tags;
+
+/**
  Returns the `SLTest` subclass with the specified name.
  
  This method may be used to retrieve a single `SLTest`, e.g. to pass to 
@@ -149,6 +162,19 @@
  @see -[SLTestController runTests:withCompletionBlock:]
  */
 + (BOOL)isFocused;
+
+/**
+ An array of NSStrings which represent tags that are associated with this test case.
+
+ Used by `+[SLTest testsWithTags:]` to determine inclusion in the test set.
+
+ Tags are case sensitive.
+
+ @return array of tags for this test, defaults to `nil` to indicate no tags.
+
+ @see -[SLTestController runTests:withCompletionBlock:]
+ */
++ (NSArray *)tags;
 
 #pragma mark - Running a Test
 /// ----------------------------------------

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -69,6 +69,24 @@ const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
     return tests;
 }
 
++ (NSSet *)testsWithTags:(NSArray *)tags {
+    NSMutableSet *tests = [[NSMutableSet alloc] init];
+
+    for (Class klass in [self allTests]) {
+        Class metaClass = object_getClass(klass);
+        if (class_respondsToSelector(metaClass, @selector(tags)) &&
+            [klass tags] != nil) {
+            NSPredicate *intersectionPredicate = [NSPredicate predicateWithFormat:@"SELF IN %@", [klass tags]];
+            if ([[tags filteredArrayUsingPredicate:intersectionPredicate] count]) {
+                // there is a match on at least one tag
+                [tests addObject:klass];
+            }
+        }
+    }
+
+    return tests;
+}
+
 + (Class)testNamed:(NSString *)name {
     NSParameterAssert(name);
     
@@ -130,6 +148,11 @@ const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
 
 - (void)tearDownTestCaseWithSelector:(SEL)testCaseSelector {
     // nothing to do here
+}
+
++ (NSArray *)tags
+{
+    return nil;
 }
 
 + (NSSet *)testCases {

--- a/Unit Tests/SLTestTests.m
+++ b/Unit Tests/SLTestTests.m
@@ -75,9 +75,83 @@
         [Focus_TestThatIsFocusedButDoesntSupportCurrentPlatform class],
         [Focus_AbstractTestThatIsFocused class],
         [ConcreteTestThatIsFocused class],
+        [TestWithTagAAA class],
+        [TestWithTagBBB class],
+        [TestWithTagCCC class],
+        [TestWithTagZZZ class],
+        [TestWithTagAAAandZZZ class],
+        [TestWithTagBBBandZZZ class],
+        [Focus_TestWithTagAAA class],
+        [Focus_TestWithTagAAAandZZZ class],
         nil
     ];
     STAssertEqualObjects(allTests, expectedTests, @"Unexpected tests returned.");
+}
+
+- (void)testTestsWithTagsReturnsExpected {
+    // one tag
+    NSSet *taggedTests = [SLTest testsWithTags:@[@"tagAAA"]];
+    NSSet *expectedTests = [NSSet setWithObjects:
+        [TestWithTagAAA class],
+        [TestWithTagAAAandZZZ class],
+        [Focus_TestWithTagAAA class],
+        [Focus_TestWithTagAAAandZZZ class],
+        nil
+    ];
+    STAssertEqualObjects(taggedTests, expectedTests, @"Unexpected tests returned.");
+
+    // one tag
+    taggedTests = [SLTest testsWithTags:@[@"tagZZZ"]];
+    expectedTests = [NSSet setWithObjects:
+        [TestWithTagAAAandZZZ class],
+        [Focus_TestWithTagAAAandZZZ class],
+        [TestWithTagZZZ class],
+        [TestWithTagBBBandZZZ class],
+        nil
+    ];
+    STAssertEqualObjects(taggedTests, expectedTests, @"Unexpected tests returned.");
+
+    // two tags
+    taggedTests = [SLTest testsWithTags:@[@"tagAAA", @"tagBBB"]];
+    expectedTests = [NSSet setWithObjects:
+        [TestWithTagAAA class],
+        [TestWithTagAAAandZZZ class],
+        [Focus_TestWithTagAAA class],
+        [Focus_TestWithTagAAAandZZZ class],
+        [TestWithTagBBB class],
+        [TestWithTagBBBandZZZ class],
+        nil
+    ];
+    STAssertEqualObjects(taggedTests, expectedTests, @"Unexpected tests returned.");
+
+    // three tags
+    taggedTests = [SLTest testsWithTags:@[@"tagAAA", @"tagBBB", @"tagCCC"]];
+    expectedTests = [NSSet setWithObjects:
+        [TestWithTagAAA class],
+        [TestWithTagAAAandZZZ class],
+        [Focus_TestWithTagAAA class],
+        [Focus_TestWithTagAAAandZZZ class],
+        [TestWithTagBBB class],
+        [TestWithTagBBBandZZZ class],
+        [TestWithTagCCC class],
+        nil
+    ];
+    STAssertEqualObjects(taggedTests, expectedTests, @"Unexpected tests returned.");
+
+
+    // union of tags
+    taggedTests = [SLTest testsWithTags:@[@"tagAAA", @"tagBBB", @"tagZZZ"]];
+    expectedTests = [NSSet setWithObjects:
+                     [TestWithTagAAA class],
+                     [TestWithTagAAAandZZZ class],
+                     [Focus_TestWithTagAAA class],
+                     [Focus_TestWithTagAAAandZZZ class],
+                     [TestWithTagBBB class],
+                     [TestWithTagBBBandZZZ class],
+                     [TestWithTagZZZ class],
+                     nil
+                     ];
+    STAssertEqualObjects(taggedTests, expectedTests, @"Unexpected tests returned.");
 }
 
 - (void)testTestNamedReturnsExpected {

--- a/Unit Tests/SharedSLTests.h
+++ b/Unit Tests/SharedSLTests.h
@@ -138,3 +138,29 @@
 - (void)testFoo;
 
 @end
+
+@interface TestWithTagAAA : SLTest
+@end
+
+@interface TestWithTagBBB : SLTest
+@end
+
+@interface TestWithTagCCC : SLTest
+@end
+
+@interface TestWithTagZZZ : SLTest
+@end
+
+@interface TestWithTagAAAandZZZ : SLTest
+@end
+
+@interface TestWithTagBBBandZZZ : SLTest
+@end
+
+@interface Focus_TestWithTagAAA : SLTest
+@end
+
+@interface Focus_TestWithTagAAAandZZZ : SLTest
+@end
+
+

--- a/Unit Tests/SharedSLTests.m
+++ b/Unit Tests/SharedSLTests.m
@@ -145,3 +145,51 @@
 - (void)testFoo {}
 
 @end
+
+@implementation TestWithTagAAA
++ (NSArray *)tags {
+    return @[@"tagAAA"];
+}
+@end
+
+@implementation TestWithTagBBB
++ (NSArray *)tags {
+    return @[@"tagBBB"];
+}
+@end
+
+@implementation TestWithTagCCC
++ (NSArray *)tags {
+    return @[@"tagCCC"];
+}
+@end
+
+@implementation TestWithTagZZZ
++ (NSArray *)tags {
+    return @[@"tagZZZ"];
+}
+@end
+
+@implementation TestWithTagAAAandZZZ
++ (NSArray *)tags {
+    return @[@"tagAAA", @"tagZZZ"];
+}
+@end
+
+@implementation TestWithTagBBBandZZZ
++ (NSArray *)tags {
+    return @[@"tagBBB", @"tagZZZ"];
+}
+@end
+
+@implementation Focus_TestWithTagAAA
++ (NSArray *)tags {
+    return @[@"tagAAA"];
+}
+@end
+
+@implementation Focus_TestWithTagAAAandZZZ
++ (NSArray *)tags {
+    return @[@"tagAAA", @"tagZZZ"];
+}
+@end


### PR DESCRIPTION
Add support for tagging tests and selectively running tests based on
tags. New +[SLTest tags] and +[SLTest testsWithTags:] methods added
for implementation. Updated unit tests included.
