### PR TITLE
Add some more logging around keyboard test failures.

### DIFF
--- a/Integration Tests/Tests/SLKeyboardTest.m
+++ b/Integration Tests/Tests/SLKeyboardTest.m
@@ -91,7 +91,7 @@
     [UIAElement([SLKeyboardKey elementWithAccessibilityLabel:kExpectedText]) tap];
     NSString *actualText = SLAskApp(text);
     SLAssertTrue([kExpectedText isEqualToString:actualText],
-                 @"Did not type character as expected.");
+                 @"Did not type character as expected: '%@' (expected) vs. '%@' (actual).", kExpectedText, actualText);
 }
 
 - (void)testHideKeyboard_iPad {


### PR DESCRIPTION
This will let us compare the intermittent failures that we're seeing on Travis
of this test case and other `SLKeyboardTest` cases, and maybe deduce
a common cause.
