### PR TITLE
Fix documentation errors

### DIFF
--- a/Sources/Classes/Internal/NSObject+SLVisibility.m
+++ b/Sources/Classes/Internal/NSObject+SLVisibility.m
@@ -51,7 +51,7 @@ const unsigned char kMinVisibleAlphaInt = 3; // 255 * 0.01 = 2.55, but our bitma
  Returns the number of points from a set of test points for which the receiver is visible in a given window.
 
  @param testPointsInWindow a C array of points to test for visibility
- @param count the number of elements in testPointsInWindow
+ @param numPoints the number of elements in testPointsInWindow
  @param window the UIWindow in which to test visibility.  This should usually be
  the receiver's window, but could be a different window, for example if the
  point is to test whether the view is in one window or a different window.

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.h
@@ -161,9 +161,6 @@
  @param elementObject An object which may or may not be a mock view.
  @param viewObject An object which may or may not be a view.
 
- @param elementObject An object which may or may not be a mock view.
- @param viewObject An object which may or may not be a view.
-
  @return YES if viewObject is a UIView and elementObject is mocking that view, otherwise NO.
  */
 + (BOOL)elementObject:(id)elementObject isMockingViewObject:(id)viewObject;


### PR DESCRIPTION
Turning on the the compiler warning for "Documentation Comments" turned up two errors. I ended up leaving that warning flag off because it was triggering errors in the upstream OCMock library, and I wasn't sure how to ignore those. 

edit: Oh, I guess a good fix would be to turn on this compiler warning just for the Subliminal target, rather than for the whole project.
