### PR TITLE
Fix the deployment targets in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ application and tests.
 Requirements
 ------------
 
-Subliminal currently supports projects built using Xcode 5.0 and the iOS 7 SDK,
-and deployment targets running iOS 5.0 through 7.0.3.
+Subliminal currently supports projects built using Xcode 5.x and iOS 7.x SDKs,
+and deployment targets running iOS 5.0 through 7.1.
 
 Continuous Integration
 ----------------------

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Requirements
 ------------
 
 Subliminal currently supports projects built using Xcode 5.x and iOS 7.x SDKs,
-and deployment targets running iOS 5.0 through 7.1.
+and deployment targets running iOS 5.1 through 7.1.
 
 Continuous Integration
 ----------------------


### PR DESCRIPTION
Regarding the minimum deployment target: Subliminal might be able to run on 5.0 just fine,
but since any device running 5.0 could upgrade to 5.1, and we're currently testing on 5.1,
I'm comfortable leaving it at 5.1.
