### PR TITLE
Add the ability to order tests by run group.

### DIFF
--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -80,7 +80,8 @@
  
  An abstract test will not itself be run. Subclasses which do define test cases
  will be run, however, allowing a single base class to define set-up and tear-down 
- work shared among related subclasses.
+ work shared among related subclasses. Abstract classes can also be used to
+ define the [run group](+runGroup) shared by subclasses.
 
  @return `YES` if the class is without test cases, otherwise `NO`.
  */
@@ -146,9 +147,39 @@
  @return `YES` if any test cases are focused and can be run on the current platform, 
  `NO` otherwise.
 
- @see -[SLTestController runTests:withCompletionBlock:]
+ @see -[SLTestController runTests:usingSeed:withCompletionBlock:]
  */
 + (BOOL)isFocused;
+
+#pragma mark - Ordering Test Runs
+/// ------------------------------------------
+/// @name Ordering Test Runs
+/// ------------------------------------------
+
+/**
+ Returns a value identifying the group of tests to which the receiver belongs.
+ 
+ `SLTestController` will run tests in ascending order of [group](+[SLTest runGroup]),
+ and then within each group, in a randomized order. This allows test writers to
+ provide a rough order to tests, where necessary, while minimizing the test pollution
+ that can result from an absolute ordering.
+ 
+ A common use for run groups is to divide tests into two groups, those that
+ need to occur before some "startup" event (an onboarding flow, an import process, etc.)
+ (of run group `1`) and those that need to occur afterward (of run group `2`).
+ In this scenario, the "post-startup" tests subclass an [abstract test](+isAbstract)
+ that, in its implementation of `+setUpTest`, causes the startup event to happen.
+ Altogether, this ensures that _all_ of the "pre-startup" tests run before
+ _any_ of the "post-startup" tests run--and that startup happens before any of the
+ "post-startup" tests happen--while allowing the tests within each group to run
+ in any order.
+
+ @return A value identifying the group of tests to which the receiver belongs.
+         The default implementation returns `1`: all tests will be part of a single run group.
+ 
+ @see -[SLTestController runTests:usingSeed:withCompletionBlock:]
+ */
++ (NSUInteger)runGroup;
 
 #pragma mark - Running a Test
 /// ----------------------------------------

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -116,6 +116,10 @@ const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
     return testSupportsCurrentDevice;
 }
 
++ (NSUInteger)runGroup {
+    return 1;
+}
+
 - (void)setUpTest {
     // nothing to do here
 }

--- a/Sources/Classes/SLTestController.h
+++ b/Sources/Classes/SLTestController.h
@@ -75,7 +75,8 @@
 /**
  Runs the specified tests.
 
- Tests are run on a background queue, in an order randomized using the specified seed.
+ Tests are run on a background queue. Tests run in ascending order of [group](+[SLTest runGroup]),
+ and then within each group, in an order randomized using the specified seed.
  Clients should generally pass `SLTestControllerRandomSeed` to let the test controller choose a seed.
  If any tests fail, the test controller will log the seed that was used,
  so that the run order may be reproduced by invoking this method with that seed.

--- a/Unit Tests/SLTestTests.m
+++ b/Unit Tests/SLTestTests.m
@@ -75,6 +75,14 @@
         [Focus_TestThatIsFocusedButDoesntSupportCurrentPlatform class],
         [Focus_AbstractTestThatIsFocused class],
         [ConcreteTestThatIsFocused class],
+        [AbstractRunGroupOneTest class],
+        [TestOneOfRunGroupOne class],
+        [TestTwoOfRunGroupOne class],
+        [AbstractRunGroupTwoTest class],
+        [TestOneOfRunGroupTwo class],
+        [TestTwoOfRunGroupTwo class],
+        [TestThreeOfRunGroupTwo class],
+        [TestOneOfRunGroupThree class],
         nil
     ];
     STAssertEqualObjects(allTests, expectedTests, @"Unexpected tests returned.");

--- a/Unit Tests/SharedSLTests.h
+++ b/Unit Tests/SharedSLTests.h
@@ -138,3 +138,50 @@
 - (void)testFoo;
 
 @end
+
+
+@interface AbstractRunGroupOneTest : SLTest
+
+@end
+
+@interface TestOneOfRunGroupOne : AbstractRunGroupOneTest
+
+- (void)testFoo;
+
+@end
+
+@interface TestTwoOfRunGroupOne : AbstractRunGroupOneTest
+
+- (void)testFoo;
+
+@end
+
+
+@interface AbstractRunGroupTwoTest : SLTest
+
+@end
+
+@interface TestOneOfRunGroupTwo : AbstractRunGroupTwoTest
+
+- (void)testFoo;
+
+@end
+
+@interface TestTwoOfRunGroupTwo : AbstractRunGroupTwoTest
+
+- (void)testFoo;
+
+@end
+
+@interface TestThreeOfRunGroupTwo : AbstractRunGroupTwoTest
+
+- (void)testFoo;
+
+@end
+
+
+@interface TestOneOfRunGroupThree : SLTest
+
+- (void)testFoo;
+
+@end

--- a/Unit Tests/SharedSLTests.m
+++ b/Unit Tests/SharedSLTests.m
@@ -145,3 +145,62 @@
 - (void)testFoo {}
 
 @end
+
+
+@implementation AbstractRunGroupOneTest
+
++ (NSUInteger)runGroup {
+    return 1;
+}
+
+@end
+
+@implementation TestOneOfRunGroupOne
+
+- (void)testFoo {}
+
+@end
+
+@implementation TestTwoOfRunGroupOne
+
+- (void)testFoo {}
+
+@end
+
+
+@implementation AbstractRunGroupTwoTest
+
++ (NSUInteger)runGroup {
+    return 2;
+}
+
+@end
+
+@implementation TestOneOfRunGroupTwo
+
+- (void)testFoo {}
+
+@end
+
+@implementation TestTwoOfRunGroupTwo
+
+- (void)testFoo {}
+
+@end
+
+@implementation TestThreeOfRunGroupTwo
+
+- (void)testFoo {}
+
+@end
+
+
+@implementation TestOneOfRunGroupThree
+
++ (NSUInteger)runGroup {
+    return 3;
+}
+
+- (void)testFoo {}
+
+@end


### PR DESCRIPTION
See the documentation on `+[SLTest runGroup]`.

This is a proposed resolution to #94 and an alternative to the mechanism implemented in #122.
