### PR TITLE
Remove TRAVIS environment variable from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,6 @@ install:
 
 env:
     global:
-        # Necessary to work around some Travis-only bugs
-        # (This should be set by Travis but is not currently:
-        # https://github.com/travis-ci/travis-ci/issues/1769)
-        - TRAVIS=true
-
         # To work around http://openradar.appspot.com/radar?id=1544403,
         # the tests need the Travis user's password.
         - LOGIN_PASSWORD="j4K7CK4oM49ZA27y532b"


### PR DESCRIPTION
You can see in [the Travis CI output](https://travis-ci.org/inkling/Subliminal/jobs/22304992) that Travis is now exporting the `TRAVIS` environment variable. I also echoed the variable to check its value in [this build](https://travis-ci.org/MaxGabriel/TestTravis/builds/22316709).

If this PR is merged, I'll also update the Subliminal [CI wiki page](https://github.com/inkling/Subliminal/wiki/Continuous-Integration).
