### PR TITLE
Allocate pixels with all zero components for bitmap context

### DIFF
--- a/Sources/Classes/Internal/NSObject+SLVisibility.m
+++ b/Sources/Classes/Internal/NSObject+SLVisibility.m
@@ -241,7 +241,7 @@ const unsigned char kMinVisibleAlphaInt = 3; // 255 * 0.01 = 2.55, but our bitma
     NSAssert(maxY >= minY, @"maxY (%d) should be greater than or equal to minY (%d)", maxY, minY);
     size_t columns = maxX - minX + 1;
     size_t rows = maxY - minY + 1;
-    unsigned char *pixels = (unsigned char *)malloc(columns * rows * 4);
+    unsigned char *pixels = (unsigned char *)calloc(columns * rows * 4, 1);
     CGContextRef context = CGBitmapContextCreate(pixels, columns, rows, 8, 4 * columns, rgbColorSpace, kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast);
     CGContextTranslateCTM(context, -minX, -minY);
     [self renderViewRecursively:window inContext:context withTargetView:self baseView:window];


### PR DESCRIPTION
We should use calloc here instead of malloc to ensure that the
pixel buffer we use for testing visibility is all clear when
nothing has been drawn yet.  This can be an issue in cases where
renderViewRecursively doesn't actually draw anything.  If nothing
is drawn then this function should return 0, but if we're unlucky
with the random values in the malloced pixel buffer we might see
something "drawn" in the pixel buffer anyway and return non-zero.
