### PR TITLE
Update `subliminal-test` to take advantage of `instruments` 5.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ language: objective-c
 
 install:
     # - `xctool`, required to build the unit test and documentation targets
-    #   nothing to do here because it's already installed on Travis
+    #   Workaround for https://github.com/travis-ci/travis-ci/issues/2051#issuecomment-40817341
+    - brew update
+    - brew upgrade xctool
 
     # - `appledoc`, used to build documentation
     #   Force the usage of appledoc 2.1 until https://github.com/inkling/Subliminal/issues/71 is addressed;

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,19 +23,16 @@ env:
         # the tests need the Travis user's password.
         - LOGIN_PASSWORD="j4K7CK4oM49ZA27y532b"
     matrix:
-        - TEST_COMMAND=test:unit                TEST_SDK=5.1
         - TEST_COMMAND=test:unit                TEST_SDK=6.1
-        - TEST_COMMAND=test:unit                TEST_SDK=7.0
+        - TEST_COMMAND=test:unit                TEST_SDK=7.1
 
         - TEST_COMMAND=test:CI_unit
 
-        - TEST_COMMAND=test:integration:iphone  TEST_SDK=5.1
         - TEST_COMMAND=test:integration:iphone  TEST_SDK=6.1
-        - TEST_COMMAND=test:integration:iphone  TEST_SDK=7.0
+        - TEST_COMMAND=test:integration:iphone  TEST_SDK=7.1
 
-        - TEST_COMMAND=test:integration:ipad    TEST_SDK=5.1
         - TEST_COMMAND=test:integration:ipad    TEST_SDK=6.1
-        - TEST_COMMAND=test:integration:ipad    TEST_SDK=7.0
+        - TEST_COMMAND=test:integration:ipad    TEST_SDK=7.1
 
         - TEST_COMMAND=build_docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ install:
 
     # - `appledoc`, used to build documentation
     #   Force the usage of appledoc 2.1 until https://github.com/inkling/Subliminal/issues/71 is addressed
-    - brew unlink appledoc
     - brew install https://raw.github.com/mxcl/homebrew/33aa810/Library/Formula/appledoc.rb
 
 ## Test matrix

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: objective-c
 
 ## Setup
 
-before_install:
-    # Fully initialize repo (i.e. test dependencies like `OCMock`)
-    - git submodule update --init --recursive
+# Travis initializes git submodules before `install` runs
 
 install:
     # - `xctool`, required to build the unit test and documentation targets

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ install:
 ## Test matrix
 
 env:
-    global:
-        # To work around http://openradar.appspot.com/radar?id=1544403,
-        # the tests need the Travis user's password.
-        - LOGIN_PASSWORD="j4K7CK4oM49ZA27y532b"
     matrix:
         - TEST_COMMAND=test:unit                TEST_SDK=6.1
         - TEST_COMMAND=test:unit                TEST_SDK=7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,13 @@ install:
     #   nothing to do here because it's already installed on Travis
 
     # - `appledoc`, used to build documentation
-    #   Force the usage of appledoc 2.1 until https://github.com/inkling/Subliminal/issues/71 is addressed
-    - brew install https://raw.github.com/mxcl/homebrew/33aa810/Library/Formula/appledoc.rb
+    #   Force the usage of appledoc 2.1 until https://github.com/inkling/Subliminal/issues/71 is addressed;
+    #   manually install the above (rather than using `brew`) because `appledoc`
+    #   can't be compiled using Xcode 5.1 and there's no bottle available for the `appledoc21` formula
+    - curl --progress-bar --output /tmp/appledoc-2.1.mountain_lion.bottle.tar.gz http://inkling.github.io/Subliminal/Documentation/appledoc-2.1.mountain_lion.bottle.tar.gz
+    - tar -C /tmp -zxf /tmp/appledoc-2.1.mountain_lion.bottle.tar.gz
+    - cp /tmp/appledoc/2.1/bin/appledoc /usr/local/bin
+    - cp -Rf /tmp/appledoc/2.1/Templates/ ~/.appledoc
 
 ## Test matrix
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,17 @@ For an installation walkthrough, refer to [Subliminal's wiki](https://github.com
 Requirements
 ------------
 
-Subliminal currently supports projects built using Xcode 5.x and iOS 7.x SDKs,
+Subliminal supports projects built using Xcode 5.1 and iOS 7.x SDKs,
 and deployment targets running iOS 5.1 through 7.1.
+
+To test against the iOS 5.1 Simulator, you will need to run Xcode 5.1 on OS X 10.8,
+and manually add the 5.1 Simulator to Xcode 5.1, as described
+[here](http://stackoverflow.com/a/22494536/495611).
+
+**NOTE**: The forthcoming Subliminal 1.1 will be the last version of Subliminal
+to officially support iOS 5.1, because Subliminal's CI infrastructure has been
+upgraded to OS X 10.9 and so no longer supports the 5.1 Simulator. (Subliminal 1.1
+will be specially tested against a local machine running 10.8.)
 
 Usage
 -----

--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ rake test\tRuns Subliminal's tests
 rake test
 rake test:unit
 rake test:CI_unit
-rake test:integration                  (LIVE=yes | LOGIN_PASSWORD=<password>)
+rake test:integration
 rake test:integration[:iphone, :ipad]
 rake test:integration:device           UDID=<udid>
 
@@ -100,6 +100,9 @@ Sub-tasks:
 \`test:integration\` invokes \`test:integration:iphone\` and \`test:integration:ipad\`.
 \`test:integration:device\` must be explicitly invoked.
 
+To run the integration tests un-attended, you must have \"pre-authorized\" \`instruments\`
+as described here: https://github.com/inkling/Subliminal/wiki/Continuous-Integration#faq.
+
 To run the integration tests on a device, you will need a valid developer identity 
 and provisioning profile. If you have a wildcard profile you will be able to run 
 the tests without creating a profile specifically for the \"Subliminal Integration Tests\" app.
@@ -112,19 +115,6 @@ by Xcode.
   TEST_SDK=<sdk>            Selects the iPhone Simulator SDK version against which to run the tests.
                             Supported values are '6.1' and '7.1'.
                             If not specified, the tests will be run against all supported SDKs.
-
-\`test:integration\` options:
-  LIVE=yes                  Indicates that the tests are being attended by a developer who can 
-                            enter their password if instruments asks for authorization. For the tests 
-                            to run un-attended, the current user's login password must be specified
-                            by \`LOGIN_PASSWORD\`.
-
-  LOGIN_PASSWORD=<password> Your login password. When instruments is launched, 
-                            it may ask for permission to take control of your application 
-                            (http://openradar.appspot.com/radar?id=1544403). 
-                            To authorize instruments during an un-attended run, the tests 
-                            require the current user's password. When running the tests live, 
-                            \`LIVE=yes\` may be specified instead.
  
 \`test:integration:device\` options:
   UDID=<udid>               The UDID of the device to target.\n\n"""
@@ -462,22 +452,10 @@ namespace :test do
 
   namespace :integration do
     def base_test_command
-      command = "\"#{SCRIPT_DIR}/subliminal-test\"\
-                -project Subliminal.xcodeproj\
-                -scheme 'Subliminal Integration Tests'\
-                --quiet_build"
-
-      if ENV["LIVE"] == "yes"
-        command << " --live"
-      else
-        login_password = ENV["LOGIN_PASSWORD"]
-        if !login_password || login_password.length == 0
-          fail "Neither \`LIVE=yes\` nor \`LOGIN_PASSWORD\` specified. See 'rake usage[test]`.\n\n"
-        end
-        command << " -login_password \"#{login_password}\""
-      end
-
-      command
+      "\"#{SCRIPT_DIR}/subliminal-test\"\
+        -project Subliminal.xcodeproj\
+        -scheme 'Subliminal Integration Tests'\
+        --quiet_build"
     end
 
     # ! because this clears old results

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ DOCSET_DIR = "#{ENV['HOME']}/Library/Developer/Shared/Documentation/DocSets"
 DOCSET_NAME = "com.inkling.Subliminal.docset"
 DOCSET_VERSION = "1.0.1"
 
-SUPPORTED_SDKS = [ "5.1", "6.1", "7.0" ]
+SUPPORTED_SDKS = [ "6.1", "7.1" ]
 TEST_SDK = ENV["TEST_SDK"]
 if TEST_SDK
   raise "Test SDK #{TEST_SDK} is not supported." unless SUPPORTED_SDKS.include?(TEST_SDK)
@@ -110,7 +110,7 @@ by Xcode.
 
 \`test\` options:
   TEST_SDK=<sdk>            Selects the iPhone Simulator SDK version against which to run the tests.
-                            Supported values are '5.1', '6.1', and '7.0'.
+                            Supported values are '6.1' and '7.1'.
                             If not specified, the tests will be run against all supported SDKs.
 
 \`test:integration\` options:
@@ -498,7 +498,7 @@ namespace :test do
 
         # Use system so we see the tests' output
         results_dir = fresh_results_dir!("iphone", sdk)
-        # Use the 3.5" iPhone Retina because that can support all 3 of our target SDKs
+        # Use the 3.5" iPhone Retina because that can support both our target SDKs
         if system("#{base_test_command} -output \"#{results_dir}\" -sim_device 'iPhone Retina (3.5-inch)' -sim_version #{sdk}")
           puts "iPhone integration tests succeeded on iOS #{sdk}.\n\n"
         else

--- a/Sources/Classes/Internal/Terminal/SLTerminal.m
+++ b/Sources/Classes/Internal/Terminal/SLTerminal.m
@@ -45,8 +45,8 @@ const NSTimeInterval SLTerminalReadRetryDelay = 0.1;
 // This is calibrated with respect to errors reported on Travis.
 // It should be a comfortable margin--the actual discrepancy between
 // Travis' execution times, and what we (had) thought would suffice,
-// is closer to 0.05.
-const NSTimeInterval SLTerminalEvaluationDelay = 0.075;
+// is closer to 0.14.
+const NSTimeInterval SLTerminalEvaluationDelay = 0.2;
 
 /**
  Identifier for the `evalQueue` for use with `dispatch_get_specific`.

--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -29,7 +29,6 @@ print_usage_and_fail () {
 	echo """
 subliminal-test (-project <project_path> | -workspace <workspace_path>) 
 		( -sim_device <device_type> | -hw_id <udid> )
-		(-login_password <password> | --live)
 		[-build_tool <tool_name>] [-scheme <scheme_name>] [-sdk <sdk>] [-replacement_bundle_id <id>] [--quiet_build]
 		[-sim_version <version>] [-timeout <timeout>] [-output <output_dir>] 
 		[-e <variable> <value>]
@@ -51,10 +50,8 @@ Otherwise, \`subliminal-test\` returns success (0).
 
   * alongside the other scripts that were originally in \`/Supporting Files/CI\`;
   * with Subliminal having been installed on the test machine, using \`rake install DOCS=no\`;
-  * and with GUI scripting enabled: if the test machine runs Mac OS X 10.8 Mountain Lion, open System Preferences and check 
-    \"Enable access for assistive devices\" in the Accessibility preference pane. If the test machine runs Mac OS X 10.9 Mavericks,
-    open System Preferences and click on \"Security & Privacy\". Select \"Accessibility\" and drag Terminal.app from Applications/Utilities 
-    into the list. Do not forget to check the box.
+  * and with \`instruments\` having been \"pre-authorized\" to take control of the application,
+  	as described here: https://github.com/inkling/Subliminal/wiki/Continuous-Integration#faq.
 
 Also make sure that your \"Integration Tests\" scheme is shared (in Xcode, click \`Product -> Schemes -> Manage Schemes…\`
 and then click the \"Shared\" checkbox next to the scheme) and checked into source control:
@@ -82,19 +79,6 @@ Required arguments:
 
 	-hw_id <udid>			The UDID of the hardware to target.
 					Either this or \`-sim_device\` must be specified.
-
-	-login_password <password>	The current user's login password. This permits 
-					this script to authorize \`instruments\` to take control
-					of your application if it asks for such permission when
-					launched: http://openradar.appspot.com/radar?id=1544403.
-
-					If a developer will be attending the tests as they execute, 
-					they may specify \`--live\` rather than provide their password.
-
-	--live				Indicates that this script is being attended by a developer
-					who can enter their password to authorize instruments.
-					For this script to run un-attended, the current user's
-					login password must be specified using \`-login_password\`.
 
 Optional build arguments:
 	-build_tool <tool_name>		The tool to use to build the scheme. Should be either \"xcrun xcodebuild\" 
@@ -170,12 +154,22 @@ BUILD_TOOL="xcrun xcodebuild"
 SCHEME="Integration Tests"
 CONFIGURATION="Release"
 
+LOGIN_PASSWORD_DEPRECATION_MESSAGE="""\n
+WARNING: The \`--live\` and \`-login_password\` options have been deprecated\n
+as of Subliminal 1.1. https://github.com/inkling/Subliminal/wiki/Continuous-Integration#faq\n
+describes how to \"pre-authorize\" \`instruments\` so that \`subliminal-test\`\n
+may run un-attended without the current user's login password.\n
+\n
+In an upcoming release, \`subliminal-instrument\` will reject the \`--live\` and\n
+\`-login_password\` options and require that \`instruments\` be pre-authorized.
+"""
+
 while :
 do
 case $1 in
 	# Must check these before the single dash options (because -* would match them)
 	--live)
-		LIVE=true
+		echo $LOGIN_PASSWORD_DEPRECATION_MESSAGE
 		shift 1;;
 
     --quiet_build)
@@ -187,7 +181,7 @@ case $1 in
 		shift 1;;
 
 	# Set argument, wait for value
-    -project|-workspace|-sim_device|-hw_id|-login_password|-build_tool|-scheme|-configuration|-sdk|-replacement_bundle_id|-sim_version|-timeout|-output|-e)
+    -project|-workspace|-sim_device|-hw_id|-build_tool|-scheme|-configuration|-sdk|-replacement_bundle_id|-sim_version|-timeout|-output|-e)
 		if [[ -n "$CURRENT_ARG" ]]; then
 			echo "Missing value for argument: $CURRENT_ARG"
 			print_usage_and_fail
@@ -199,6 +193,13 @@ case $1 in
 			*)	CURRENT_ARG=`echo ${1#-} | tr [[:lower:]] [[:upper:]]`;;
 		esac
 	    shift 1;;
+
+	-login_password)
+		echo $LOGIN_PASSWORD_DEPRECATION_MESSAGE
+		# While `-login_password` is deprecated, we still need to use it (if present)
+		# to try to authorize `instruments` in case the user has not yet pre-authorized `instruments`
+		CURRENT_ARG=LOGIN_PASSWORD
+		shift 1;;
 
     -*)	
 		echo "Unrecognized argument: $1"
@@ -233,8 +234,7 @@ fi
 
 # Enforce required args
 if [[ ( -z "$PROJECT" && -z "$WORKSPACE" ) || 
-	( -z "$SIM_DEVICE" && -z "$HW_ID" ) || 
-	( -z "$LOGIN_PASSWORD" && -z "$LIVE" ) ]]; then
+	  ( -z "$SIM_DEVICE" && -z "$HW_ID" ) ]]; then
 	echo "Missing required arguments"
 	print_usage_and_fail
 fi
@@ -490,10 +490,10 @@ if [[ -z $VERBOSE_LOGGING ]] || ! $VERBOSE_LOGGING; then
 	defaults write com.apple.dt.InstrumentsCLI UIAVerboseLogging 4096
 fi
 
-# Attempt to authorize instruments to take control of the application
-# Unless the user indicated otherwise
-if [[ -z $LIVE ]] || ! $LIVE; then
-	# First attempt to authorize instruments when it is launched: 
+# If `-login_password` was specified (i.e. the user has not yet pre-authorized `instruments`)
+# attempt to authorize instruments using the password
+if [[ -n "$LOGIN_PASSWORD" ]]; then
+	# First attempt to authorize `instruments` when it is launched: 
 	# in the background, monitor for, and dismiss, the dialog it shows
 	osascript "$SCRIPT_DIR/authorize_instruments.scpt" "$LOGIN_PASSWORD" &
 	# Track pid to be killed when the parent script ends
@@ -501,7 +501,8 @@ if [[ -z $LIVE ]] || ! $LIVE; then
 fi
 
 launch_instruments () {
-	# Second attempt (in case the dialog does not show, as in certain CI environments 
+	# Second attempt to authorize `instruments` ourselves
+	# (in case the dialog does not show, as in certain CI environments 
 	# like Travis): enter the login password on the command line, 
 	# by piping the password, followed by a newline, to instruments
 	# (If the user did not supply a login password, this will just print a newline)

--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -53,7 +53,7 @@ Otherwise, \`subliminal-test\` returns success (0).
   * with Subliminal having been installed on the test machine, using \`rake install DOCS=no\`;
   * and with GUI scripting enabled: if the test machine runs Mac OS X 10.8 Mountain Lion, open System Preferences and check 
     \"Enable access for assistive devices\" in the Accessibility preference pane. If the test machine runs Mac OS X 10.9 Mavericks,
-    open System Preferences and click on "Security & Privacy". Select "Accessibility" and drag Terminal.app from Applications/Utilities 
+    open System Preferences and click on \"Security & Privacy\". Select \"Accessibility\" and drag Terminal.app from Applications/Utilities 
     into the list. Do not forget to check the box.
 
 Also make sure that your \"Integration Tests\" scheme is shared (in Xcode, click \`Product -> Schemes -> Manage Schemes…\`

--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -68,29 +68,32 @@ Required arguments:
 					Either this or \`-project\` must be specified.
 
 	-sim_device <device_type>	The type of device to simulate.
-					Acceptable values are listed in the iOS Simulator's 
-					\"Hardware -> Device\" menu. Either this or \`-hw_id\` must 
-					be specified.
+					Acceptable values are listed by executing \`instruments -s devices\`:
+					given a listing like \"iPad - Simulator - iOS 7.1\", the device
+					type is the first dash-separated component, trimmed of spaces,
+					e.g. \"iPad\".
+
+					Note that (despite the response of \`instruments -s devices\`)
+					the iOS Simulator does not accept certain combinations 
+					of device type and SDK (as specified using the \`-sim_version\`
+					argument), e.g. \"iPhone\" and \"7.1\".
+
+					Either this or \`-hw_id\` must be specified.
 
 	-hw_id <udid>			The UDID of the hardware to target.
 					Either this or \`-sim_device\` must be specified.
 
 	-login_password <password>	The current user's login password. This permits 
-					this script to work around several bugs in Apple's \`instruments\` 
-					tool while running un-attended. The password is used: 
-
-					  1. To authorize \`instruments\` to take control of your application if 
-					     it asks for such permission when launched: http://openradar.appspot.com/radar?id=1544403.
-					  2. To temporarily modify the Xcode folder to force \`instruments\` 
-					     to use the specified SDK to run the tests, whereas it would otherwise use
-					     an arbitrary SDK: http://openradar.appspot.com/radar?id=3107401.
+					this script to authorize \`instruments\` to take control
+					of your application if it asks for such permission when
+					launched: http://openradar.appspot.com/radar?id=1544403.
 
 					If a developer will be attending the tests as they execute, 
 					they may specify \`--live\` rather than provide their password.
 
-	--live				Indicates that this script is being attended by a developer who can 
-					enter their password to authorize instruments and/or to disable SDKs not
-					targeted by the tests. For this script to run un-attended, the current user's
+	--live				Indicates that this script is being attended by a developer
+					who can enter their password to authorize instruments.
+					For this script to run un-attended, the current user's
 					login password must be specified using \`-login_password\`.
 
 Optional build arguments:
@@ -125,12 +128,11 @@ Optional build arguments:
 
 Optional testing arguments:
 	-sim_version <version>		The version of the iOS Simulator SDK to test with, 
-					e.g. 5.1 or 6.1. Defaults to the latest iOS Simulator SDK 
+					e.g. 6.1 or 7.1. Defaults to the latest iOS Simulator SDK 
 					installed. Ignored if \`-sim_device\` is not specified.
 
 					Note that the iOS Simulator does not accept certain combinations 
-					of device type and SDK, e.g. \"iPhone Retina (4-inch)\" 
-					and \"5.1\".
+					of device type and SDK, e.g. \"iPhone\" and \"7.1\".
 
 	-timeout <timeout>		The maximum duration for which to run the tests before aborting.
 					Specified in milliseconds and as a number rather than a string. Defaults to infinite.
@@ -237,53 +239,6 @@ if [[ ( -z "$PROJECT" && -z "$WORKSPACE" ) ||
 	print_usage_and_fail
 fi
 
-# This function allows simulator SDKs to be enabled/disabled 
-# to work around http://openradar.appspot.com/radar?id=3107401
-# It must be declared here because it is called from `cleanup_and_exit`
-enable_SDK_version_or_all () {
-	SDK_VERSION="$1"
-
-	# An SDK is disabled by changing its settings plist's extension to "disabled",
-	# causing it to be ignored by instruments
-	enable_SDK_at_path () {
-		SDK_PATH="$1"
-		ENABLE="$2"
-
-		# Modifying the Xcode folder will require authorization 
-		SUDO_INPUT=`([[ -z $LIVE ]] || ! $LIVE) && echo "-S" || echo ""`
-
-		SDK_VERSION=`echo "$SDK_PATH" | perl -pe 's|.*iphonesimulator(.+)\.sdk|$1|i'`
-		SDK_SETTINGS=`find "$SDK_PATH" -maxdepth 1 -name "SDKSettings.*"`
-		if [[ -n "$ENABLE" ]] && ! $ENABLE && [[ "$SDK_SETTINGS" == *.plist ]]; then
-			echo "Disabling SDK $SDK_VERSION by changing the extension of \`$SDK_SETTINGS\` to \`*.disabled\`..."
-
-			# If the user did not specify a login password, this will just print a newline
-			printf "$LOGIN_PASSWORD\n" | sudo $SUDO_INPUT mv "$SDK_SETTINGS" "$SDK_PATH/SDKSettings.disabled"
-		elif [[ -n "$ENABLE" ]] && $ENABLE && [[ "$SDK_SETTINGS" == *.disabled ]]; then
-			echo "Re-enabling SDK $SDK_VERSION by changing the extension of \`$SDK_SETTINGS\` back to \`*.plist\`..."
-
-			printf "$LOGIN_PASSWORD\n" | sudo $SUDO_INPUT mv "$SDK_SETTINGS" "$SDK_PATH/SDKSettings.plist"
-		fi
-	}
-	# so that the subshell used by find -exec can call this function
-	export -f enable_SDK_at_path
-	export LOGIN_PASSWORD
-	export LIVE
-
-	# If a SDK version is passed, disable all other SDKs 
-	if [[ -n "$SDK_VERSION" ]]; then
-		# The quoting of "xcode-select" is just so that "select" doesn't mess up this file's syntax highlighting
-		find "$('xcode-select' -print-path)" \
-			-iname "iphonesimulator*.sdk" -and -not -iname "iphonesimulator${SDK_VERSION}.sdk" \
-			-exec bash -c 'enable_SDK_at_path "$0" $1' {} false ';'
-	else
-		# Otherwise, (re)enable all SDKs
-		find "$('xcode-select' -print-path)" \
-			-iname "iphonesimulator*.sdk" \
-			-exec bash -c 'enable_SDK_at_path "$0" $1' {} true ';'
-	fi
-}
-
 # resets the simulator, or uninstalls the app from the device 
 # (the best that we can do, given device support
 # --also probably better not to be as destructive as a reset on a device)
@@ -347,11 +302,6 @@ reinstall_app_on_device () {
 
 # This function allows the script to abort at any point below without duplicating cleanup logic
 cleanup_and_exit () {
-	# Re-enable all simulator SDKs if necessary
-	echo ""
-	enable_SDK_version_or_all
-	echo ""
-
 	kill -9 $AUTHORIZE_INSTRUMENTS_PID 2> /dev/null
 	kill -9 $INSTRUMENTS_PID 2> /dev/null
 	kill -9 $KILL_INSTRUMENTS_PID 2> /dev/null
@@ -409,26 +359,6 @@ if [[ -z "$SDK" ]]; then
 	SDK=`[[ -n "$SIM_DEVICE" ]] && echo "iphonesimulator" || echo "iphoneos"`
 fi
 
-# instruments always uses the iPad simulator for universal binaries,
-# so to choose a simulated device type we've got to override the TARGETED_DEVICE_FAMILY at build.
-# http://openradar.appspot.com/13607967
-TARGETED_DEVICE_FAMILY_ARG=""
-if [[ -n "$SIM_DEVICE" ]]; then
-	case $SIM_DEVICE in
-		iPhone*)
-			DEVICE_FAMILY=1
-			;;
-		iPad*)
-			DEVICE_FAMILY=2
-			;;
-		*)
-			echo "\nERROR: Unrecognized device type."
-			cleanup_and_exit 1
-			;;
-	esac
-	TARGETED_DEVICE_FAMILY_ARG="TARGETED_DEVICE_FAMILY=$DEVICE_FAMILY"
-fi
-
 # This is a function so that it may be called again if instruments hiccups; see below.
 build_app () {
 	# Clear build products from a prior run if any.
@@ -461,7 +391,6 @@ build_app () {
 			-scheme "$SCHEME"\
 			-configuration "$CONFIGURATION"\
 			-sdk "$SDK"\
-			$TARGETED_DEVICE_FAMILY_ARG\
 			SYMROOT="$BUILD_DIR"\
 			VALIDATE_PRODUCT=NO $1
 	}
@@ -516,12 +445,9 @@ if [[ -n "$SIM_DEVICE" ]]; then
 		echo "- Setting the version to $SIM_VERSION (Simulator version not specified--defaulting to latest simulator installed)"
 	fi
 
-	# The instruments command-line tool picks an arbitrary SDK depending on toolchain version:
-	# http://openradar.appspot.com/radar?id=3107401
-	# We must disable the SDKs other than the one we're targeting 
-	# to force it to use the simulator's current setting
-	enable_SDK_version_or_all "$SIM_VERSION"
-
+	# We don't strictly need to set the device type here--instruments uses whatever
+	# device is specified when it is launched, not what was previously in use
+	# --but it's nice to see in the logs, also we need to reset the simulator anyway
 	echo "- Setting the device to \"$SIM_DEVICE\""
 	echo "- Resetting simulator content and settings"
 
@@ -583,12 +509,12 @@ launch_instruments () {
 	# Note that the Subliminal trace template includes the UIASCRIPT
 	# and the environment variables passed to this script
 	# are passed to instruments and the app by being exported at the top of this script
-	TIMEOUT_ARG=`[[ -n "$TIMEOUT" ]] && echo "-l $TIMEOUT" || echo ""`
-	HARDWARE_ARG=`[[ -n "$HW_ID" ]] && echo "-w $HW_ID" || echo ""`
+	local timeout_arg=`[[ -n "$TIMEOUT" ]] && echo "-l $TIMEOUT" || echo ""`
+	local device=`[[ -n "$HW_ID" ]] && echo "$HW_ID" || echo "$SIM_DEVICE - Simulator - iOS $SIM_VERSION"`
 	printf "$LOGIN_PASSWORD\n" | "$SCRIPT_DIR/subliminal-instrument.sh"\
 		-D "$TRACE_FILE"\
-		$TIMEOUT_ARG\
-		$HARDWARE_ARG\
+		$timeout_arg\
+		-w "$device"\
 		"$APP"\
 		-e UIARESULTSPATH "$RESULTS_DIR" &
 	INSTRUMENTS_PID=$!
@@ -647,17 +573,8 @@ while ([ ! -e "$RESULT_LOG" ] || grep -qi "Please relaunch the tests" "$RESULT_L
 	(( INSTRUMENTS_RETRY_COUNT++ ))
 	echo "\nInstruments hiccuped; retrying with clean build and a timeout of $CURRENT_LAUNCH_TIMEOUT seconds...\n"
 
-	# Re-enable all simulator SDKs (if necessary) while we build
-	echo ""
-	enable_SDK_version_or_all
-	echo ""
-
 	build_app
 	[ $? -eq 0 ] || cleanup_and_exit 1
-
-	# Now once again disable those other than the one we're targeting
-	[[ -n "$SIM_VERSION" ]] && enable_SDK_version_or_all "$SIM_VERSION"
-	echo ""
 
 	# Reset the simulator/reinstall the app on the device 
 	# in case instruments installed the app and then aborted


### PR DESCRIPTION
Resolves #143--we now use `instruments` 5.1's ability to select the device type and SDK, and ask the user to pre-authorize the test machine rather than provide their login password to `subliminal-test`.

[The wiki](https://github.com/inkling/Subliminal/wiki/Continuous-Integration) has already been updated in anticipation of these changes.
