### PR TITLE
Add ability to use FOCUS environment variable to focus tests

### DIFF
--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -151,6 +151,43 @@
  */
 + (BOOL)isFocused;
 
+/**
+ Returns YES if the test has at least one test case which is focused
+ using an environment variable named `FOCUS` on the tested application's Integration
+ Tests scheme and which can run on the current platform.
+
+ When a test is run, if any of its test cases are focused, only those test cases will run.
+ This may be useful when writing or debugging tests.
+
+ In Xcode, test cases are focused by listing the desired tests, separated
+ by commas, as the Integration Tests scheme's `FOCUS` environment variable's value.
+
+ Using the subliminal-test script to run Subliminal from the command line for continuous
+ integration, test cases are focused like so:
+
+ subliminal-test [...] -e FOCUS testFoo,testBar
+
+ It is also possible to implicitly focus all test cases by listing their test's name
+ in the `FOCUS` environment variable. But if some test cases are explicitly focused
+ (as above), only those test cases will run--the narrowest focus applies.
+
+ If a test is focused, that focus will apply to any tests which descend from it.
+
+ @warning Methods that take test case selectors as arguments (like
+ `-setUpTestCaseWithSelector:`) are invoked with the unfocused form of the selectors
+ --they need not (and should not) be modified when a test case is focused.
+
+ @warning Focused test cases will not be run if their test is not run (e.g. if
+ it is not included in the set of tests to be run, or if it does not support
+ the current platform).
+
+ @return `YES` if any test cases are focused and can be run on the current platform,
+ `NO` otherwise.
+
+ @see -[SLTestController runTests:usingSeed:withCompletionBlock:]
+ */
++ (BOOL)isFocusedWithEnvVar;
+
 #pragma mark - Ordering Test Runs
 /// ------------------------------------------
 /// @name Ordering Test Runs

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -95,6 +95,16 @@ const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
     return NO;
 }
 
++ (BOOL)isFocusedWithEnvVar {
+    for (NSString *testCaseName in [self envVarFocusedTestCases]) {
+        SEL testCaseSelector = NSSelectorFromString(testCaseName);
+        if ([self testCaseWithSelectorSupportsCurrentPlatform:testCaseSelector]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
 + (BOOL)supportsCurrentPlatform {
     // examine whether this test or any of its superclasses are annotated
     // the "nearest" annotation determines support ("nearest" like with method overrides)
@@ -208,8 +218,51 @@ const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
     return focusedTestCases;
 }
 
++ (NSSet *)envVarFocusedTestCases {
+    static const void *const kEnvVarFocusedTestCasesKey = &kEnvVarFocusedTestCasesKey;
+    NSSet *envVarFocusedTestCases = objc_getAssociatedObject(self, kEnvVarFocusedTestCasesKey);
+    if (!envVarFocusedTestCases) {
+        NSSet *testCases = [self testCases];
+
+        // if any test cases are specified in the FOCUS envvar
+        NSString *envTests = [[[NSProcessInfo processInfo] environment] objectForKey:@"FOCUS"];
+        NSArray *envTestsArray = [envTests componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@", \t"]];
+        envVarFocusedTestCases = [testCases filteredSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSString *testCase, NSDictionary *bindings) {
+            return [envTestsArray containsObject:testCase];
+        }]];
+
+        // otherwise, if our class' name (or the name of any superclass) is specified,
+        // all test cases are focused
+        if (![envVarFocusedTestCases count]) {
+            BOOL classIsFocused = NO;
+            Class testClass = self;
+            while (testClass != [SLTest class]) {
+                if ([envTestsArray containsObject:NSStringFromClass(testClass)]) {
+                    classIsFocused = YES;
+                    break;
+                }
+                testClass = [testClass superclass];
+            }
+            if (classIsFocused) {
+                envVarFocusedTestCases = [testCases copy];
+            }
+        }
+
+        objc_setAssociatedObject(self, kEnvVarFocusedTestCasesKey, envVarFocusedTestCases, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return envVarFocusedTestCases;
+}
+
 + (NSSet *)testCasesToRun {
-    NSSet *baseTestCases = (([self isFocused]) ? [self focusedTestCases] : [self testCases]);
+    NSSet *baseTestCases;
+    if ([self isFocusedWithEnvVar]) {
+        baseTestCases = [self envVarFocusedTestCases];
+    } else if ([self isFocused]) {
+        baseTestCases = [self focusedTestCases];
+    } else {
+        baseTestCases = [self testCases];
+    }
+    
     return [baseTestCases filteredSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
         // pass the unfocused selector, as focus is temporary and shouldn't require modifying the test infrastructure
         SEL unfocusedTestCaseSelector = NSSelectorFromString([self unfocusedTestCaseName:evaluatedObject]);

--- a/Sources/Classes/SLTestController.m
+++ b/Sources/Classes/SLTestController.m
@@ -196,9 +196,17 @@ u_int32_t random_uniform(u_int32_t upperBound) {
     // ...that support the current platform...
     [testsToRun filterUsingPredicate:[NSPredicate predicateWithFormat:@"supportsCurrentPlatform == YES"]];
 
-    // ...and that are focused (if any remaining are focused)
+    // ...and that are focused (if any remaining are focused)...
     NSMutableArray *focusedTests = [testsToRun mutableCopy];
-    [focusedTests filterUsingPredicate:[NSPredicate predicateWithFormat:@"isFocused == YES"]];
+
+    // ...if tests to focus are listed in the FOCUS environment variable, use those. Otherwise, filter by "focus_" prefix
+    NSString *envTests = [[[NSProcessInfo processInfo] environment] objectForKey:@"FOCUS"];
+    if ([envTests length] > 0) {
+        [focusedTests filterUsingPredicate:[NSPredicate predicateWithFormat:@"isFocusedWithEnvVar == YES"]];
+    } else {
+        [focusedTests filterUsingPredicate:[NSPredicate predicateWithFormat:@"isFocused == YES"]];
+    }
+
     BOOL runningWithFocus = ([focusedTests count] > 0);
     if (runningWithFocus) {
         testsToRun = focusedTests;


### PR DESCRIPTION
We found that our CI test runs were getting really long and wanted to split them up into multiple jobs, so we came up with this and have been using it for 3 months without any issues. It has the same behaviour as prepending tests with `focus_`, but it works using a `FOCUS` environment variable on the Integration Tests scheme, which can then be set for each CI job with `subliminal-test [...] -e FOCUS testFoo,testBar`.

We couldn't figure out a way to write tests for this, given that it's checking the environment variables for the list of tests to run, but let me know if you can think of something.
