### PR TITLE
Fix UITextView accessibility path when contained within a UITableViewCell

### DIFF
--- a/Integration Tests/Tests/SLTextFieldTest.m
+++ b/Integration Tests/Tests/SLTextFieldTest.m
@@ -40,8 +40,10 @@
     [super setUpTestCaseWithSelector:testSelector];
 
     if (testSelector == @selector(testSetText) ||
+        testSelector == @selector(testSetTextWithinTableViewCell) ||
         testSelector == @selector(testSetTextCanHandleTapHoldCharacters) ||
         testSelector == @selector(testSetTextClearsCurrentText) ||
+        testSelector == @selector(testSetTextClearsCurrentTextWithinTableViewCell) ||
         testSelector == @selector(testSetTextWhenFieldClearsOnBeginEditing) ||
         testSelector == @selector(testGetText) ||
         testSelector == @selector(testDoNotMatchEditorAccessibilityObjects) ||
@@ -68,6 +70,12 @@
     SLAssertTrue([SLAskApp(text) isEqualToString:expectedText], @"Text was not set to expected value.");
 }
 
+- (void)testSetTextWithinTableViewCell {
+    NSString *const expectedText = @"foo";
+    SLAssertNoThrow([UIAElement(_textField) setText:expectedText], @"Should not have thrown.");
+    SLAssertTrue([SLAskApp(text) isEqualToString:expectedText], @"Text was not set to expected value.");
+}
+
 - (void)testSetTextCanHandleTapHoldCharacters {
     NSString *const expectedText = @"foo’s a difficult string to type!";
     SLAssertNoThrow([UIAElement(_textField) setText:expectedText], @"Should not have thrown.");
@@ -75,6 +83,16 @@
 }
 
 - (void)testSetTextClearsCurrentText {
+    NSString *const expectedText1 = @"foo";
+    SLAssertNoThrow([UIAElement(_textField) setText:expectedText1], @"Should not have thrown.");
+    SLAssertTrue([SLAskApp(text) isEqualToString:expectedText1], @"Text was not set to expected value.");
+
+    NSString *const expectedText2 = @"bar";
+    SLAssertNoThrow([UIAElement(_textField) setText:expectedText2], @"Should not have thrown.");
+    SLAssertTrue([SLAskApp(text) isEqualToString:expectedText2], @"Text was not set to expected value.");
+}
+
+- (void)testSetTextClearsCurrentTextWithinTableViewCell {
     NSString *const expectedText1 = @"foo";
     SLAssertNoThrow([UIAElement(_textField) setText:expectedText1], @"Should not have thrown.");
     SLAssertTrue([SLAskApp(text) isEqualToString:expectedText1], @"Text was not set to expected value.");

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
@@ -373,6 +373,9 @@
 
 
 @implementation UITableViewCell (SLAccessibilityHierarchy)
+- (BOOL)classForcesPresenceInAccessibilityHierarchy {
+    return YES;
+}
 - (BOOL)classForcesPresenceOfMockingViewsInAccessibilityHierarchy {
     return YES;
 }
@@ -393,7 +396,8 @@
 
 @implementation UIScrollView (SLAccessibilityHierarchy)
 - (BOOL)classForcesPresenceInAccessibilityHierarchy {
-    return YES;
+    return kCFCoreFoundationVersionNumber <= kCFCoreFoundationVersionNumber_iOS_6_1 ||
+           ![[(UIView *)self superview] isKindOfClass:[UITableViewCell class]];
 }
 @end
 


### PR DESCRIPTION
In iOS7, having a UITextView within a UITableViewCell doesn't appear to work as expected. The fix appears to function as expected. 

I haven't fixed the second test case that I added, and clear current text doesn't appear to work on either iOS 6 or iOS 7. I'll be debugging this issue now.
