### PR TITLE
Allow Class objects to be passed to selectors

### DIFF
--- a/Sources/Classes/SLTestController+AppHooks.m
+++ b/Sources/Classes/SLTestController+AppHooks.m
@@ -103,7 +103,8 @@ NSString *const SLAppActionTargetDoesNotExistException = @"SLAppActionTargetDoes
     // note that there are always at least two arguments, for self and _cmd
     NSAssert(numberOfArguments < 4, @"The action must identify a method which takes zero or one argument.");
     if (numberOfArguments == 3) {
-        NSAssert(strcmp([actionSignature getArgumentTypeAtIndex:2], @encode(id<NSCopying>)) == 0,
+        NSAssert(strcmp([actionSignature getArgumentTypeAtIndex:2], @encode(id<NSCopying>)) == 0 ||
+                 strcmp([actionSignature getArgumentTypeAtIndex:2], @encode(Class)) == 0,
                  @"If the action takes an argument, that argument must be of type id<NSCopying>.");
     }
 


### PR DESCRIPTION
The Class object conforms to NSCopying, so there is no reason they shouldn't be able to be passed as a parameter to a selector. I was thinking about using this to see if the current main windows rootViewController matched the one I was expecting. I'm rethinking the approach, but I don't see why it shouldn't at least be possible.
