### PR TITLE
Disable integration test transition animations when running in CI.

### DIFF
--- a/Integration Tests/SLIntegrationTestsAppDelegate.m
+++ b/Integration Tests/SLIntegrationTestsAppDelegate.m
@@ -56,7 +56,15 @@
         // Filter the tests for the `SLTestController`
         // so that the `SLTestsViewController` only displays appropriate tests
         _tests = [SLTestController testsToRun:[SLTest allTests] usingSeed:NULL withFocus:NULL];
-        rootViewController = [[SLTestsViewController alloc] initWithTests:_tests];
+        SLTestsViewController *testsViewController = [[SLTestsViewController alloc] initWithTests:_tests];
+
+        // animate test transitions by default
+        BOOL animateTestTransitions = YES;
+        // but not if we're running in CI
+        if (getenv("CI") && [@(getenv("CI")) isEqualToString:@"true"]) animateTestTransitions = NO;
+        testsViewController.animateTestTransitions = animateTestTransitions;
+
+        rootViewController = testsViewController;
     }
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:rootViewController];
     self.window.rootViewController = navController;

--- a/Integration Tests/SLTestViewController.h
+++ b/Integration Tests/SLTestViewController.h
@@ -48,6 +48,15 @@
  */
 - (instancetype)initWithTest:(Class)test testCases:(NSSet *)testCases;
 
+/**
+ A Boolean value that indicates whether the view controller
+ should animate the presentation and dismissal of test cases.
+ 
+ The default value of this property is `YES`, which causes the view controller
+ to animate the presentation and dismissal of test cases.
+ */
+@property (nonatomic) BOOL animateTestCaseTransitions;
+
 #pragma mark - SLIntegrationTest App Hooks
 /// --------------------------------------------
 /// @name SLIntegrationTest App Hooks

--- a/Integration Tests/SLTestViewController.m
+++ b/Integration Tests/SLTestViewController.m
@@ -43,6 +43,7 @@ NSString *const SLTestCaseViewControllerClassNameKey = @"SLTestCaseViewControlle
     if (self) {
         _test = test;
         _testCases = [testCases allObjects];
+        _animateTestCaseTransitions = YES;
     }
     return self;
 }
@@ -106,10 +107,10 @@ NSString *const SLTestCaseViewControllerClassNameKey = @"SLTestCaseViewControlle
                           scrollPosition:UITableViewScrollPositionNone];
     [self.tableView scrollToRowAtIndexPath:indexPath
                           atScrollPosition:UITableViewScrollPositionNone
-                                  animated:YES];
+                                  animated:self.animateTestCaseTransitions];
 
     // wait until any scrolling animation might have concluded--they're of uniform duration
-    double scrollingDelayInSeconds = 0.3;
+    double scrollingDelayInSeconds = self.animateTestCaseTransitions ? 0.3 : 0.0;
     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(scrollingDelayInSeconds * NSEC_PER_SEC));
     dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
         // now that the row for the pending test case has been scrolled to visible,
@@ -121,7 +122,7 @@ NSString *const SLTestCaseViewControllerClassNameKey = @"SLTestCaseViewControlle
 
         // ensure that we'll receive the callback
         self.navigationController.delegate = self;
-        [self.navigationController pushViewController:testCaseViewController animated:YES];
+        [self.navigationController pushViewController:testCaseViewController animated:self.animateTestCaseTransitions];
     });
 }
 
@@ -149,7 +150,7 @@ NSString *const SLTestCaseViewControllerClassNameKey = @"SLTestCaseViewControlle
 - (void)dismissCurrentTestCase {
     // ensure that we'll receive the callback
     self.navigationController.delegate = self;
-    [self.navigationController popToViewController:self animated:YES];
+    [self.navigationController popToViewController:self animated:self.animateTestCaseTransitions];
 }
 
 @end

--- a/Integration Tests/SLTestsViewController.h
+++ b/Integration Tests/SLTestsViewController.h
@@ -47,6 +47,15 @@
  */
 - (instancetype)initWithTests:(NSArray *)tests;
 
+/**
+ A Boolean value that indicates whether the view controller
+ should animate the presentation and dismissal of tests.
+ 
+ The default value of this property is `YES`, which causes the view controller
+ to animate the presentation and dismissal of tests.
+ */
+@property (nonatomic) BOOL animateTestTransitions;
+
 #pragma mark - SLIntegrationTest App Hooks
 /// ------------------------------------
 /// @name SLIntegrationTest App Hooks

--- a/Integration Tests/SLTestsViewController.m
+++ b/Integration Tests/SLTestsViewController.m
@@ -41,6 +41,7 @@ NSString *const SLTestCasesKey = @"SLTestCasesKey";
     self = [super initWithStyle:UITableViewStylePlain];
     if (self) {
         _tests = [tests copy];
+        _animateTestTransitions = YES;
     }
     return self;
 }
@@ -104,19 +105,20 @@ NSString *const SLTestCasesKey = @"SLTestCasesKey";
                           scrollPosition:UITableViewScrollPositionNone];
     [self.tableView scrollToRowAtIndexPath:indexPath
                           atScrollPosition:UITableViewScrollPositionNone
-                                  animated:YES];
+                                  animated:self.animateTestTransitions];
 
     // wait until any scrolling animation might have concluded--they're of uniform duration
-    double scrollingDelayInSeconds = 0.3;
+    double scrollingDelayInSeconds = self.animateTestTransitions ? 0.3 : 0.0;
     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(scrollingDelayInSeconds * NSEC_PER_SEC));
     dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
         // now that the row for the pending test has been scrolled to visible,
         // present its test cases
         SLTestViewController *testViewController = [[SLTestViewController alloc] initWithTest:test testCases:_pendingTestInfo[SLTestCasesKey]];
+        testViewController.animateTestCaseTransitions = self.animateTestTransitions;
 
         // ensure that we'll receive the callback
         self.navigationController.delegate = self;
-        [self.navigationController pushViewController:testViewController animated:YES];
+        [self.navigationController pushViewController:testViewController animated:self.animateTestTransitions];
     });
 }
 
@@ -144,7 +146,7 @@ NSString *const SLTestCasesKey = @"SLTestCasesKey";
 - (void)dismissCurrentTest {
     // ensure that we'll receive the callback
     self.navigationController.delegate = self;
-    [self.navigationController popToViewController:self animated:YES];
+    [self.navigationController popToViewController:self animated:self.animateTestTransitions];
 }
 
 @end

--- a/Integration Tests/Tests/SLStatusBarTestViewController.m
+++ b/Integration Tests/Tests/SLStatusBarTestViewController.m
@@ -20,12 +20,26 @@
     return @"SLStatusBarTestViewController";
 }
 
+- (instancetype)initWithTestCaseWithSelector:(SEL)testCase {
+    self = [super initWithTestCaseWithSelector:testCase];
+    if (self) {
+        [[SLTestController sharedTestController] registerTarget:self forAction:@selector(contentOffsetY)];
+    }
+    return self;
+}
+
 - (void)dealloc {
     [[SLTestController sharedTestController] deregisterTarget:self];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
     self.scrollView.contentSize = CGSizeMake(CGRectGetWidth(self.scrollView.bounds), 2000.0);
+}
+
+#pragma mark - App Hooks
+
+- (NSNumber *)contentOffsetY {
+    return @(self.scrollView.contentOffset.y);
 }
 
 @end

--- a/Integration Tests/Tests/SLTextFieldTestViewController.m
+++ b/Integration Tests/Tests/SLTextFieldTestViewController.m
@@ -144,7 +144,7 @@
         return;
 
     // move the textfield above the keyboard
-    static const CGFloat kTextFieldVerticalOffset = -40.0f;
+    static const CGFloat kTextFieldVerticalOffset = -80.0f;
 
     CGPoint textFieldCenter = CGPointMake(self.view.center.x, self.view.center.y + kTextFieldVerticalOffset);
     _textField.center = textFieldCenter;


### PR DESCRIPTION
There's no one watching in that case, and disabling animations speeds up the tests
by about 40%.
