### PR TITLE
A button can't be found when within the header view of a table view

### DIFF
--- a/Integration Tests/Tests/SLElementMatchingTest.m
+++ b/Integration Tests/Tests/SLElementMatchingTest.m
@@ -249,6 +249,17 @@
     SLAssertFalse([cityLabel isValid], @"Should not be able to match individual child label.");
 }
 
+- (void)testMatchingElementsWithinTableHeaderView {
+    SLAssertTrue([[UIAElement([SLButton elementWithAccessibilityLabel:@"Button 1"]) label] isEqualToString:@"Button 1"],
+                 @"Couldn't find the first button within the table view!");
+    SLAssertTrue([[UIAElement([SLButton elementWithAccessibilityLabel:@"Button 2"]) label] isEqualToString:@"Button 2"],
+                 @"Couldn't find the second button within the table view!");
+    SLAssertTrue([[UIAElement([SLStaticText elementWithAccessibilityLabel:@"Label 1"]) label] isEqualToString:@"Label 1"],
+                 @"Couldn't find the first label within the table view!");
+    SLAssertTrue([[UIAElement([SLStaticText elementWithAccessibilityLabel:@"Label 2"]) label] isEqualToString:@"Label 2"],
+                 @"Couldn't find the second label within the table view!");
+}
+
 // matching child elements may be done on a per-element basis (e.g. controls)
 // the Accessibility Inspector reports the ground truth
 - (void)testMatchingNonLabelTableViewCellChildElement {

--- a/Integration Tests/Tests/SLElementMatchingTestViewController.m
+++ b/Integration Tests/Tests/SLElementMatchingTestViewController.m
@@ -212,6 +212,9 @@
                                                     UICollectionViewDataSource, UICollectionViewDelegate,
                                                     UIWebViewDelegate >
 
+@property (weak, nonatomic) UIViewController *storyboardViewController;
+
+
 // fooButton is purposely strong so that we can hold onto it
 // while it's removed from the view hierarchy in testElementsWaitToMatchValidObjects
 @property (strong, nonatomic) IBOutlet UIButton *fooButton;
@@ -326,6 +329,14 @@
         _collectionView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
         self.view = _collectionView;
+    } else if (testCase == @selector(testMatchingElementsWithinTableHeaderView)) {
+        UIStoryboard *sb = [UIStoryboard storyboardWithName:@"SLTestMatchingElementsWithinTableHeaderView" bundle:nil];
+        self.storyboardViewController = [sb instantiateInitialViewController];
+        [self addChildViewController:self.storyboardViewController];
+
+        UIView *view = [[UIView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+        [view addSubview:self.storyboardViewController.view];
+        self.view = view;
     }
 }
 

--- a/Integration Tests/Tests/SLTestMatchingElementsWithinTableHeaderView.storyboard
+++ b/Integration Tests/Tests/SLTestMatchingElementsWithinTableHeaderView.storyboard
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="eF4-CN-uHW">
+    <dependencies>
+        <deployment defaultVersion="1296" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+    </dependencies>
+    <scenes>
+        <!--Table View Controller-->
+        <scene sceneID="DWC-s7-yoS">
+            <objects>
+                <tableViewController id="eF4-CN-uHW" sceneMemberID="viewController">
+                    <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="NUb-uh-KPt">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <view key="tableHeaderView" contentMode="scaleToFill" id="a1H-nd-Zco">
+                            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="WSS-Hj-pDQ">
+                                    <rect key="frame" x="15" y="455" width="290" height="44"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                    <state key="normal" title="Button 1">
+                                        <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    </state>
+                                    <state key="disabled">
+                                        <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                    </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </state>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="BXR-lU-GY8">
+                                    <rect key="frame" x="15" y="509" width="290" height="44"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                    <state key="normal" title="Button 2">
+                                        <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    </state>
+                                    <state key="disabled">
+                                        <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                    </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </state>
+                                </button>
+                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Label 2" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9Ya-P0-q4B">
+                                    <rect key="frame" x="20" y="259" width="280" height="51"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <color key="textColor" red="0.46666666670000001" green="0.50196078430000002" blue="0.53333333329999999" alpha="1" colorSpace="calibratedRGB"/>
+                                    <nil key="highlightedColor"/>
+                                    <color key="shadowColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <size key="shadowOffset" width="0.0" height="0.0"/>
+                                </label>
+                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Label 1" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" adjustsFontSizeToFit="NO" id="b6g-nc-YNw">
+                                    <rect key="frame" x="15" y="228" width="290" height="23"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                    <color key="textColor" red="0.23921568630000001" green="0.25882352939999997" blue="0.27450980390000002" alpha="1" colorSpace="calibratedRGB"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                            <color key="backgroundColor" red="0.91372549020000005" green="0.92549019610000005" blue="0.93333333330000001" alpha="1" colorSpace="calibratedRGB"/>
+                        </view>
+                        <sections/>
+                    </tableView>
+                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <navigationItem key="navigationItem" id="oIh-AY-Y4b"/>
+                    <nil key="simulatedTopBarMetrics"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="hwA-yr-4vN" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-4184" y="-4673"/>
+        </scene>
+    </scenes>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4"/>
+    </simulatedMetricsContainer>
+</document>

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
@@ -179,11 +179,18 @@
 - (BOOL)accessibilityAncestorPreventsPresenceInAccessibilityHierarchy {
     // An object will not appear in the accessibility hierarchy
     // if an ancestor is an accessibility element.
-    id parent = [self slAccessibilityParent];
+    id parent = [self slAccessibilityParent], child = self;
     while (parent) {
         if ([parent isAccessibilityElement]) {
-            return YES;
+            // Although `UITableView` makes an exception (as always):
+            // objects within its header or footer views may appear in the hierarchy.
+            if (!([parent isKindOfClass:[UITableView class]] &&
+                  (child == ((UITableView *)parent).tableHeaderView ||
+                   child == ((UITableView *)parent).tableFooterView))) {
+                return YES;
+            }
         }
+        child = parent;
         parent = [parent slAccessibilityParent];
     }
 

--- a/Subliminal.xcodeproj/project.pbxproj
+++ b/Subliminal.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		6256A2D419476E1F00C6507F /* SLStaticTextTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6256A2D119476E1F00C6507F /* SLStaticTextTest.m */; };
 		6256A2D519476E1F00C6507F /* SLStaticTextTestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6256A2D219476E1F00C6507F /* SLStaticTextTestViewController.m */; };
 		6256A2D619476E1F00C6507F /* SLStaticTextTestViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6256A2D319476E1F00C6507F /* SLStaticTextTestViewController.xib */; };
+		627B5FD4194FACA50059B692 /* SLTestMatchingElementsWithinTableHeaderView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 627B5FD0194FA9D70059B692 /* SLTestMatchingElementsWithinTableHeaderView.storyboard */; };
 		62E7A633193EF84C00CB11AB /* SLStaticText.h in Headers */ = {isa = PBXBuildFile; fileRef = 62E7A631193EF84C00CB11AB /* SLStaticText.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		62E7A634193EF84C00CB11AB /* SLStaticText.m in Sources */ = {isa = PBXBuildFile; fileRef = 62E7A632193EF84C00CB11AB /* SLStaticText.m */; };
 		CA75E78216697A1200D57E92 /* SLDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = CA75E78016697A1200D57E92 /* SLDevice.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -304,6 +305,7 @@
 		6256A2D119476E1F00C6507F /* SLStaticTextTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLStaticTextTest.m; sourceTree = "<group>"; };
 		6256A2D219476E1F00C6507F /* SLStaticTextTestViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLStaticTextTestViewController.m; sourceTree = "<group>"; };
 		6256A2D319476E1F00C6507F /* SLStaticTextTestViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SLStaticTextTestViewController.xib; sourceTree = "<group>"; };
+		627B5FD0194FA9D70059B692 /* SLTestMatchingElementsWithinTableHeaderView.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = SLTestMatchingElementsWithinTableHeaderView.storyboard; sourceTree = "<group>"; };
 		62E7A631193EF84C00CB11AB /* SLStaticText.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLStaticText.h; sourceTree = "<group>"; };
 		62E7A632193EF84C00CB11AB /* SLStaticText.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLStaticText.m; sourceTree = "<group>"; };
 		CA75E78016697A1200D57E92 /* SLDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLDevice.h; sourceTree = "<group>"; };
@@ -707,6 +709,7 @@
 				068D3E4C16DE9008004E7E28 /* SLTableViewChildElementMatchingTestViewController.xib */,
 				F08005581730762C00198F6F /* Inklings~iPhone.webarchive */,
 				622DA0B2194CCF2600EFFE05 /* SLTextFieldPicker.m */,
+				627B5FD0194FA9D70059B692 /* SLTestMatchingElementsWithinTableHeaderView.storyboard */,
 			);
 			name = "SLElement Matching Tests";
 			sourceTree = "<group>";
@@ -1303,6 +1306,7 @@
 				F00800C9174B3349001927AC /* SLButtonTestViewController.xib in Resources */,
 				F00F3B5E1778E05100119580 /* SLElementTapTestScrollViewCases.xib in Resources */,
 				F00F3B6717790B4C00119580 /* SLStaticElementTestScrollView.xib in Resources */,
+				627B5FD4194FACA50059B692 /* SLTestMatchingElementsWithinTableHeaderView.storyboard in Resources */,
 				0640035B178FDE7800479173 /* SLElementTouchAndHoldTestViewController.xib in Resources */,
 				F0A3F63F17A7172E007529C3 /* SLTextViewTestViewController.xib in Resources */,
 				F0A3F64117A73198007529C3 /* SLWebTextView.html in Resources */,


### PR DESCRIPTION
I have a screen with a button that can't be found within a table view. The reason is because it is failing the check for -accessibilityAncestorPreventsPresenceInAccessibilityHierarchy. However, I have a view where the UITableView is showing up as being an accessibility element, so the UIButton that is being filtered out by Subliminal.

I want to see if there are any issues with this change being compatible with existing tests. It seems to fix my problem at least in this case.
