### PR TITLE
Allow SLAssert methods to be called from non SLTest subclass methods

### DIFF
--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -409,10 +409,19 @@
 })
 
 #pragma mark - Test Assertions
+/**
+ The SLAssert* class of methods should only be used from test setup, teardown,
+ or execution methods as well as those methods called from within.
+
+ @warning If you use an assertion inside a dispatch block--if your test case
+ dispatches to the main queue, for instance--you must wrap the assertion in a
+ try-catch block and re-throw the exception it generates (if any) outside the
+ dispatch block. Otherwise, the tests will abort with an unhandled exception.
+ */
 
 /**
  Fails the test case if the specified expression is false.
- 
+
  @param expression The expression to test.
  @param failureDescription A format string specifying the error message 
  to be logged if the test fails. Can be `nil`.

--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -386,7 +386,7 @@
  @param filename A filename, i.e. the last component of the `__FILE__` macro's expansion.
  @param lineNumber A line number, i.e. the `__LINE__` macro's expansion.
  */
-- (void)recordLastKnownFile:(const char *)filename line:(int)lineNumber;
++ (void)recordLastKnownFile:(const char *)filename line:(int)lineNumber;
 
 /**
  Records the current filename and line number and returns its argument.
@@ -404,7 +404,7 @@
  UIAutomation element corresponding to the wrapped `SLUIAElement`."
  */
 #define UIAElement(slElement) ({ \
-    [self recordLastKnownFile:__FILE__ line:__LINE__]; \
+    [SLTest recordLastKnownFile:__FILE__ line:__LINE__]; \
     slElement; \
 })
 
@@ -420,7 +420,7 @@
  `failureDescription`.
  */
 #define SLAssertTrue(expression, failureDescription, ...) do { \
-    [self recordLastKnownFile:__FILE__ line:__LINE__]; \
+    [SLTest recordLastKnownFile:__FILE__ line:__LINE__]; \
     BOOL __result = !!(expression); \
     if (!__result) { \
         NSString *__reason = [NSString stringWithFormat:@"\"%@\" should be true.%@", \
@@ -471,7 +471,7 @@
  to be logged if the test fails. Can be `nil`.
  */
 #define SLAssertTrueWithTimeout(expression, timeout, failureDescription, ...) do {\
-    [self recordLastKnownFile:__FILE__ line:__LINE__]; \
+    [SLTest recordLastKnownFile:__FILE__ line:__LINE__]; \
     \
     if (!SLWaitUntilTrue(expression, timeout)) { \
         NSString *reason = [NSString stringWithFormat:@"\"%@\" did not become true within %g seconds.%@", \
@@ -526,7 +526,7 @@
  `failureDescription`.
  */
 #define SLAssertFalse(expression, failureDescription, ...) do { \
-    [self recordLastKnownFile:__FILE__ line:__LINE__]; \
+    [SLTest recordLastKnownFile:__FILE__ line:__LINE__]; \
     BOOL __result = !!(expression); \
     if (__result) { \
         NSString *__reason = [NSString stringWithFormat:@"\"%@\" should be false.%@", \
@@ -545,7 +545,7 @@
  `failureDescription`.
  */
 #define SLAssertThrows(expression, failureDescription, ...) do { \
-    [self recordLastKnownFile:__FILE__ line:__LINE__]; \
+    [SLTest recordLastKnownFile:__FILE__ line:__LINE__]; \
     BOOL __caughtException = NO; \
     @try { \
         (expression); \
@@ -572,7 +572,7 @@
  `failureDescription`.
  */
 #define SLAssertThrowsNamed(expression, exceptionName, failureDescription, ...) do { \
-    [self recordLastKnownFile:__FILE__ line:__LINE__]; \
+    [SLTest recordLastKnownFile:__FILE__ line:__LINE__]; \
     BOOL __caughtException = NO; \
     @try { \
         (expression); \
@@ -608,7 +608,7 @@
  `failureDescription`.
  */
 #define SLAssertNoThrow(expression, failureDescription, ...) do { \
-    [self recordLastKnownFile:__FILE__ line:__LINE__]; \
+    [SLTest recordLastKnownFile:__FILE__ line:__LINE__]; \
     @try { \
         (expression); \
     } \

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -40,10 +40,10 @@ NSString *const SLTestAssertionFailedException  = @"SLTestCaseAssertionFailedExc
 const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
 
 
-@implementation SLTest {
-    NSString *_lastKnownFilename;
-    int _lastKnownLineNumber;
-}
+@implementation SLTest
+
+static NSString *_lastKnownFilename;
+static int _lastKnownLineNumber;
 
 + (NSSet *)allTests {
     NSMutableSet *tests = [[NSMutableSet alloc] init];
@@ -264,7 +264,7 @@ const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
 
                 // clear call site information, so at the least it won't be reused between test cases
                 // (though we can't guarantee it won't be reused within a test case)
-                [self clearLastKnownCallSite];
+                [SLTest clearLastKnownCallSite];
 
                 BOOL caseFailed = NO, failureWasExpected = NO;
                 @try {
@@ -340,12 +340,12 @@ const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
     [NSThread sleepForTimeInterval:interval];
 }
 
-- (void)recordLastKnownFile:(const char *)filename line:(int)lineNumber {
++ (void)recordLastKnownFile:(const char *)filename line:(int)lineNumber {
     _lastKnownFilename = [@(filename) lastPathComponent];
     _lastKnownLineNumber = lineNumber;
 }
 
-- (void)clearLastKnownCallSite {
++ (void)clearLastKnownCallSite {
     _lastKnownFilename = nil;
     _lastKnownLineNumber = 0;
 }
@@ -367,7 +367,7 @@ const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
 
     // Regardless of whether we used it or not,
     // call site info is now stale
-    [self clearLastKnownCallSite];
+    [SLTest clearLastKnownCallSite];
 
     return exception;
 }

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -42,8 +42,8 @@ const NSTimeInterval SLWaitUntilTrueRetryDelay = 0.25;
 
 @implementation SLTest
 
-static NSString *_lastKnownFilename;
-static int _lastKnownLineNumber;
+static NSString *__lastKnownFilename;
+static int __lastKnownLineNumber;
 
 + (NSSet *)allTests {
     NSMutableSet *tests = [[NSMutableSet alloc] init];
@@ -341,13 +341,13 @@ static int _lastKnownLineNumber;
 }
 
 + (void)recordLastKnownFile:(const char *)filename line:(int)lineNumber {
-    _lastKnownFilename = [@(filename) lastPathComponent];
-    _lastKnownLineNumber = lineNumber;
+    __lastKnownFilename = [@(filename) lastPathComponent];
+    __lastKnownLineNumber = lineNumber;
 }
 
 + (void)clearLastKnownCallSite {
-    _lastKnownFilename = nil;
-    _lastKnownLineNumber = 0;
+    __lastKnownFilename = nil;
+    __lastKnownLineNumber = 0;
 }
 
 - (NSException *)exceptionByAddingFileInfo:(NSException *)exception {
@@ -355,12 +355,12 @@ static int _lastKnownLineNumber;
     // and if the exception was thrown by `SLTest` or `SLUIAElement`,
     // where the information was likely to have been recorded by an assertion or UIAElement macro.
     // Otherwise it is likely stale.
-    if (_lastKnownFilename &&
+    if (__lastKnownFilename &&
         ([[exception name] hasPrefix:SLTestExceptionNamePrefix] ||
          [[exception name] hasPrefix:SLUIAElementExceptionNamePrefix])) {
         NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:[exception userInfo]];
-        userInfo[SLLoggerExceptionFilenameKey] = _lastKnownFilename;
-        userInfo[SLLoggerExceptionLineNumberKey] = @(_lastKnownLineNumber);
+        userInfo[SLLoggerExceptionFilenameKey] = __lastKnownFilename;
+        userInfo[SLLoggerExceptionLineNumberKey] = @(__lastKnownLineNumber);
 
         exception = [NSException exceptionWithName:[exception name] reason:[exception reason] userInfo:userInfo];
     }


### PR DESCRIPTION
What do you think about this? I was planning on building a library of helper methods to build up the test cases, but unless they subclass SLTest, I can't call the assert methods. This doesn't seem right to me. 

This is my proposed solutions, but I wanted to get some thoughts.
