### PR TITLE
Fix environment variable issue for testing on device

### DIFF
--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -158,6 +158,7 @@ SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 BUILD_TOOL="xcrun xcodebuild"
 SCHEME="Integration Tests"
 CONFIGURATION="Release"
+ENV_STR=" "
 
 LOGIN_PASSWORD_DEPRECATION_MESSAGE="""\n
 WARNING: The \`--live\` and \`-login_password\` options have been deprecated\n
@@ -219,6 +220,7 @@ case $1 in
 			elif [[ "$CURRENT_ARG" == "-e" ]]; then
 				# Replace the env var placeholder
 				CURRENT_ARG="export $1"
+				ENV_STR+=" -e $1 $2"
 			else
 				eval $CURRENT_ARG=\"$1\"
 				unset CURRENT_ARG;
@@ -533,7 +535,8 @@ launch_instruments () {
 		$timeout_arg\
 		-w "$device"\
 		"$APP"\
-		-e UIARESULTSPATH "$RESULTS_DIR" &
+		-e UIARESULTSPATH "$RESULTS_DIR" \
+		$ENV_STR &
 	INSTRUMENTS_PID=$!
 
 	RESULT_LOG="$RESULTS_DIR/Run 1/Automation Results.plist"

--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -158,7 +158,7 @@ SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 BUILD_TOOL="xcrun xcodebuild"
 SCHEME="Integration Tests"
 CONFIGURATION="Release"
-ENV_STR=" "
+ENV_STR=""
 
 LOGIN_PASSWORD_DEPRECATION_MESSAGE="""\n
 WARNING: The \`--live\` and \`-login_password\` options have been deprecated\n
@@ -194,7 +194,7 @@ case $1 in
 		fi
 		case $1 in
 			# Set a placeholder for the real arg (the env var)
-			-e) CURRENT_ARG="$1";;
+			-e) CURRENT_ARG="-e";;
 			# Variables (apart from env vars) are capitalized in this script
 			*)	CURRENT_ARG=`echo ${1#-} | tr [[:lower:]] [[:upper:]]`;;
 		esac
@@ -218,9 +218,12 @@ case $1 in
 				echo "Value \"$1\" is missing argument"
 				print_usage_and_fail
 			elif [[ "$CURRENT_ARG" == "-e" ]]; then
-				# Replace the env var placeholder
-				CURRENT_ARG="export $1"
-				ENV_STR+=" -e $1 $2"
+				# Add variable name to the placeholder
+				CURRENT_ARG="-e $1"
+			elif [[ "$CURRENT_ARG" == "-e "* ]]; then
+				# Append "-e <variable_name> <variable_value>" to the environment string
+				ENV_STR+=" $CURRENT_ARG $1"
+				unset CURRENT_ARG
 			else
 				eval $CURRENT_ARG=\"$1\"
 				unset CURRENT_ARG;


### PR DESCRIPTION
When I run the test on device, the environment variables passed to subliminal-test are not available. This patch passed the exact same environment variables to "subliminal-instrument.sh" in launch_instruments() function.
