### PR TITLE
Adding a better description to SLAlertHandler

### DIFF
--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.h
@@ -48,7 +48,7 @@ typedef NS_ENUM(NSInteger, SLAlertTextFieldType) {
  dismisses the alert. The test then asks the handler to see if the alert was 
  dismissed as expected.
  
-    SLAlert *alert = [SLAlert alertWithTitle:@"foo];
+    SLAlert *alert = [SLAlert alertWithTitle:@"foo"];
 
     // dismiss an alert with title "foo", when it appears
     SLAlertHandler *handler = [alert dismiss];

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
@@ -314,6 +314,10 @@ static BOOL SLAlertHandlerLoggingEnabled = NO;
     return [[SLAlertMultiHandler alloc] initWithSLAlert:_alert handlers:@[ self, nextHandler ]];
 }
 
+- (NSString *)description {
+    return [NSString stringWithFormat:@"%@: Alert: %@", [super description], _alert];
+}
+
 @end
 
 @implementation SLAlertMultiHandler


### PR DESCRIPTION
I thought this would be useful in general when an alert asserts, and wanting more information in the assert itself. We have a scenario where we expect more than 1 alert to be fired and it would be helpful to know which alert isn't being found.
