### PR TITLE
Fix UIA path for elements within an Alert's view

### DIFF
--- a/Integration Tests/Tests/SLAlertTest.m
+++ b/Integration Tests/Tests/SLAlertTest.m
@@ -98,6 +98,26 @@
                  @"The handler should have dismissed the alert using the default button.");
 }
 
+- (void)testManuallyHandlingParticularAlertsInTestCode {
+    NSString *cancelButtonTitle = @"Cancel";
+    NSString *defaultButtonTitle = @"Ok";
+
+    // We can mark particular alerts to be left onscreen to be interacted with manually
+    NSString *alertTitle = @"Test Alert";
+    SLAlert *alert = [SLAlert alertWithTitle:alertTitle];
+    SLAlertHandler *handler = [alert dismissByTest];
+    [SLAlertHandler addHandler:handler];
+
+    SLAskApp1(showAlertWithInfo:, (@{   @"title":   alertTitle,
+                                        @"cancel":  cancelButtonTitle,
+                                        @"other":   defaultButtonTitle }));
+    SLAssertTrueWithTimeout([handler didHandleAlert], SLAlertHandlerDidHandleAlertDelay, @"Handler should have handled an alert.");
+    SLAssertNoThrow([[SLButton elementWithAccessibilityLabel:defaultButtonTitle] tap], @"The default button couldn't be found to tap!");
+    SLAssertTrueWithTimeout(SLAskApp(titleOfLastButtonClicked) != nil, SLAlertHandlerDidHandleAlertDelay, @"The alert handler wasn't invoked.");
+    SLAssertTrue([SLAskApp(titleOfLastButtonClicked) isEqualToString:defaultButtonTitle],
+                 @"The handler should have dismissed the alert using the default button.");
+}
+
 - (void)testHandlerMustBeAddedBeforeAlertShows {
     NSString *cancelButtonTitle = @"Cancel";
     NSString *defaultButtonTitle = @"Ok";

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
@@ -301,7 +301,10 @@
     if ([self.subviews count]) {
         isPopover = [self.subviews[0] isKindOfClass:[UIPopoverBackgroundView class]];
     }
-    return isPopover;
+
+    BOOL isAlertContainer = [NSStringFromClass([self class]) isEqualToString:@"_UIModalItemAlertContentView"];
+
+    return isPopover || isAlertContainer;
 }
 
 // An object is a mock view if its `accessibilityIdentifier` tracks

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
@@ -302,9 +302,11 @@
         isPopover = [self.subviews[0] isKindOfClass:[UIPopoverBackgroundView class]];
     }
 
-    BOOL isAlertContainer = [NSStringFromClass([self class]) isEqualToString:@"_UIModalItemAlertContentView"];
+    // Assuming that if the window is not owned by the application, it is probably an alert. Rather than
+    // string checking against a private class, keeping all view's in the path for this case.
+    BOOL isInAlertWindow = ![[[UIApplication sharedApplication] windows] containsObject:[self window]];
 
-    return isPopover || isAlertContainer;
+    return isPopover || isInAlertWindow;
 }
 
 // An object is a mock view if its `accessibilityIdentifier` tracks

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.h
@@ -106,6 +106,15 @@ typedef NS_ENUM(NSInteger, SLAlertTextFieldType) {
 - (SLAlertDismissHandler *)dismiss;
 
 /**
+ Creates and returns a handler that leaves the matching alert on the screen, and it
+ is up to the test case to find and handle the alert in the view hierarchy to proceed.
+
+ @return A newly created handler that dismisses the corresponding alert using
+ UIAutomation's default procedure.
+ */
+- (SLAlertDismissHandler *)dismissByTest;
+
+/**
  Creates and returns a handler that dismisses a matching alert
  by tapping the button with the specified title.
 
@@ -281,6 +290,8 @@ extern const NSTimeInterval SLAlertHandlerDidHandleAlertDelay;
 @end
 
 
+#if DEBUG
+
 /**
  The methods in the `SLAlert (Debugging)` category are to be used only to 
  debug Subliminal tests.
@@ -305,6 +316,8 @@ extern const NSTimeInterval SLAlertHandlerDidHandleAlertDelay;
 - (SLAlertDismissHandler *)dismissByUser;
 
 @end
+
+#endif
 
 /**
  The methods in the `SLAlertHandler (Debugging)` category may be useful 

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.h
@@ -281,8 +281,6 @@ extern const NSTimeInterval SLAlertHandlerDidHandleAlertDelay;
 @end
 
 
-#if DEBUG
-
 /**
  The methods in the `SLAlert (Debugging)` category are to be used only to 
  debug Subliminal tests.
@@ -307,8 +305,6 @@ extern const NSTimeInterval SLAlertHandlerDidHandleAlertDelay;
 - (SLAlertDismissHandler *)dismissByUser;
 
 @end
-
-#endif
 
 /**
  The methods in the `SLAlertHandler (Debugging)` category may be useful 

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.h
@@ -109,8 +109,7 @@ typedef NS_ENUM(NSInteger, SLAlertTextFieldType) {
  Creates and returns a handler that leaves the matching alert on the screen, and it
  is up to the test case to find and handle the alert in the view hierarchy to proceed.
 
- @return A newly created handler that dismisses the corresponding alert using
- UIAutomation's default procedure.
+ @return A newly created handler that leaves the alert untouched.
  */
 - (SLAlertDismissHandler *)dismissByTest;
 

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
@@ -448,9 +448,6 @@ static BOOL SLAlertHandlerLoggingEnabled = NO;
 
 @end
 
-
-#if DEBUG
-
 @implementation SLAlert (Debugging)
 
 - (SLAlertDismissHandler *)dismissByUser {
@@ -462,5 +459,3 @@ static BOOL SLAlertHandlerLoggingEnabled = NO;
 }
 
 @end
-
-#endif

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
@@ -368,6 +368,10 @@ static BOOL SLAlertHandlerLoggingEnabled = NO;
     return [[SLAlertDismissHandler alloc] initWithSLAlert:self andUIAAlertHandler:[SLAlertHandler defaultUIAAlertHandler]];
 }
 
+- (SLAlertDismissHandler *)dismissByTest {
+    return [[SLAlertDismissHandler alloc] initWithSLAlert:self andUIAAlertHandler:@"return true;"];
+}
+
 - (SLAlertDismissHandler *)dismissWithButtonTitled:(NSString *)buttonTitle {
     static NSString *buttonElementWithTitleFunction;
     static dispatch_once_t onceToken;
@@ -448,6 +452,9 @@ static BOOL SLAlertHandlerLoggingEnabled = NO;
 
 @end
 
+
+#if DEBUG
+
 @implementation SLAlert (Debugging)
 
 - (SLAlertDismissHandler *)dismissByUser {
@@ -459,3 +466,5 @@ static BOOL SLAlertHandlerLoggingEnabled = NO;
 }
 
 @end
+
+#endif


### PR DESCRIPTION
There is a missing element that appears in the UIA path that is being trimmed in Subliminal. This change is needed in order to find elements in an alert window. I'm not sure if my solution is acceptable of comparing against the class name of _UIModalItemAlertContentView as a string.

The reason for doing this is because we have two alerts that pop up back to back in a particular case. When this happens, we need to ensure that the alerts are handled in a specific order, as the second alert pops in front of the first one while UIA is trying to tap on the first one. This leads to a timing issue and causes the tests to fail randomly. Ignoring the first alert and handling it manually seemed like a simpler solution than trying to modify the alert handler's behavior to respect insertion order.
