### PR TITLE
When an alert handler fails to run, log useful information

### DIFF
--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
@@ -135,15 +135,21 @@ static BOOL SLAlertHandlerLoggingEnabled = NO;
                 // enumerate registered handlers, from first to last
                 @"for (var handlerIndex = 0; handlerIndex < SLAlertHandler.alertHandlers.length; handlerIndex++) {\
                     var handler = SLAlertHandler.alertHandlers[handlerIndex];"
-                    // if a handler matches the alert...
-                    @"if (handler.handleAlert(alert) === true) {\
-                        if (SLAlertHandler.loggingEnabled) UIALogger.logMessage('Alert was handled by a test.');"
-                        // ...ensure that the alert's delegate will receive its callbacks
-                        // before the next JS command (i.e. -didHandleAlert) evaluates...
-                        @"UIATarget.localTarget().delay(%g);"
-                        // ...then remove the handler and return true
-                        @"SLAlertHandler.alertHandlers.splice(handlerIndex, 1);\
-                        return true;\
+                    @"try {"
+                        // if a handler matches the alert...
+                        @"if (handler.handleAlert(alert) === true) {\
+                            if (SLAlertHandler.loggingEnabled) UIALogger.logMessage('Alert was handled by a test.');"
+                            // ...ensure that the alert's delegate will receive its callbacks
+                            // before the next JS command (i.e. -didHandleAlert) evaluates...
+                            @"UIATarget.localTarget().delay(%g);"
+                            // ...then remove the handler and return true
+                            @"SLAlertHandler.alertHandlers.splice(handlerIndex, 1);\
+                            return true;\
+                        }\
+                    } catch (e) {\
+                        UIALogger.logError('Alert handler threw an exception!');\
+                        UIATarget.localTarget().logElementTree();\
+                        throw e;\
                     }\
                 }"
                 

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
@@ -135,7 +135,9 @@ static BOOL SLAlertHandlerLoggingEnabled = NO;
                 // enumerate registered handlers, from first to last
                 @"for (var handlerIndex = 0; handlerIndex < SLAlertHandler.alertHandlers.length; handlerIndex++) {\
                     var handler = SLAlertHandler.alertHandlers[handlerIndex];"
-                    @"try {"
+                    // Give the UIA default 5s for UI interactions done purely in JS with no ObjC fallback
+                    @"UIATarget.localTarget().pushTimeout(5);\
+                    try {"
                         // if a handler matches the alert...
                         @"if (handler.handleAlert(alert) === true) {\
                             if (SLAlertHandler.loggingEnabled) UIALogger.logMessage('Alert was handled by a test.');"
@@ -150,6 +152,8 @@ static BOOL SLAlertHandlerLoggingEnabled = NO;
                         UIALogger.logError('Handler for alert \"' + alert.name() + '\" threw an exception!');\
                         UIATarget.localTarget().logElementTree();\
                         SLAlertHandler.alertHandlers.splice(handlerIndex, 1);\
+                    } finally {\
+                        UIATarget.localTarget().popTimeout();\
                     }\
                 }"
                 
@@ -399,12 +403,7 @@ static BOOL SLAlertHandlerLoggingEnabled = NO;
     NSString *UIAAlertHandler = [NSString stringWithFormat:@"\
                                      var buttonElement = (%@)('%@');\
                                      if (buttonElement && buttonElement.isValid()) {\
-                                        UIATarget.localTarget().pushTimeout(2);\
-                                        try {\
-                                            buttonElement.tap();\
-                                        } finally {\
-                                            UIATarget.localTarget().popTimeout();\
-                                        }\
+                                        buttonElement.tap();\
                                         return true;\
                                      } else {\
                                         return false;\

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
@@ -147,9 +147,9 @@ static BOOL SLAlertHandlerLoggingEnabled = NO;
                             return true;\
                         }\
                     } catch (e) {\
-                        UIALogger.logError('Alert handler threw an exception!');\
+                        UIALogger.logError('Handler for alert \"' + alert.name() + '\" threw an exception!');\
                         UIATarget.localTarget().logElementTree();\
-                        throw e;\
+                        SLAlertHandler.alertHandlers.splice(handlerIndex, 1);\
                     }\
                 }"
                 

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLAlert.m
@@ -399,7 +399,12 @@ static BOOL SLAlertHandlerLoggingEnabled = NO;
     NSString *UIAAlertHandler = [NSString stringWithFormat:@"\
                                      var buttonElement = (%@)('%@');\
                                      if (buttonElement && buttonElement.isValid()) {\
-                                        buttonElement.tap();\
+                                        UIATarget.localTarget().pushTimeout(2);\
+                                        try {\
+                                            buttonElement.tap();\
+                                        } finally {\
+                                            UIATarget.localTarget().popTimeout();\
+                                        }\
                                         return true;\
                                      } else {\
                                         return false;\

--- a/Supporting Files/CI/subliminal-instrument/subliminal-instrument/SISLLogParser.m
+++ b/Supporting Files/CI/subliminal-instrument/subliminal-instrument/SISLLogParser.m
@@ -157,8 +157,10 @@
 
                     // message format: "SLKeyboardTest.m:62: ..."
                     NSArray *messageComponents = [message componentsSeparatedByString:@":"];
-                    infoValue[@"fileName"] = messageComponents[0];
-                    infoValue[@"lineNumber"] = @([messageComponents[1] integerValue]);
+                    if (messageComponents.count > 2) {
+                        infoValue[@"fileName"] = messageComponents[0];
+                        infoValue[@"lineNumber"] = @([messageComponents[1] integerValue]);
+                    }
                 }
             } else {
                 typeValue = SISLLogEventTypeDefault;

--- a/Supporting Files/CI/subliminal-instrument/subliminal-instrument/SISLLogParser.m
+++ b/Supporting Files/CI/subliminal-instrument/subliminal-instrument/SISLLogParser.m
@@ -155,9 +155,12 @@
                 } else {
                     subtypeValue = SISLLogEventSubtypeTestFailure;
 
-                    // message format: "SLKeyboardTest.m:62: ..."
                     NSArray *messageComponents = [message componentsSeparatedByString:@":"];
+
+                    // In some rare circumstances, Subliminal may log an error with no call site,
+                    // for example when an error is raised within the JS code.
                     if (messageComponents.count > 2) {
+                        // Subliminal standard message format: "SLKeyboardTest.m:62: ..."
                         infoValue[@"fileName"] = messageComponents[0];
                         infoValue[@"lineNumber"] = @([messageComponents[1] integerValue]);
                     }


### PR DESCRIPTION
When an alert handler fails to run, log some useful information. When I added this, it appears subliminal-instrument would crash with an index out of bounds exception.

Thoughts?
