### PR TITLE
Add support for tagging tests and test cases.

### DIFF
--- a/Integration Tests/Tests/SLElementDraggingTest.m
+++ b/Integration Tests/Tests/SLElementDraggingTest.m
@@ -36,6 +36,20 @@ static const CGFloat kBottomLabelYOffset = 0.2;
     return @"SLElementDraggingTestViewController";
 }
 
++ (BOOL)testCaseWithSelectorSupportsCurrentEnvironment:(SEL)testCaseSelector {
+    if (![super testCaseWithSelectorSupportsCurrentEnvironment:testCaseSelector]) return NO;
+    
+    if ((testCaseSelector == @selector(testDraggingSimple)) ||
+        (testCaseSelector == @selector(testDraggingPrecise))) {
+        // Do not run these test cases on Travis, because even very simple scrolling tests
+        // fail regularly on the Travis machines.  These tests seem to work fine in
+        // other CI environments (such as Jenkins), but on Travis they're unreliable.
+        if (getenv("TRAVIS")) return NO;
+    }
+    
+    return YES;
+}
+
 - (void)setUpTest {
 	[super setUpTest];
     _scrollView = [SLElement elementWithAccessibilityIdentifier:@"drag scrollview"];
@@ -46,14 +60,6 @@ static const CGFloat kBottomLabelYOffset = 0.2;
 /// despite UIAutomation reporting it not being tappable when running
 /// on the iPad 5.1 Simulator (though error messages are logged).
 - (void)testDraggingSimple {
-    // Do not run this test on Travis, because even very simple scrolling tests
-    // fail regularly on the Travis machines.  These tests seem to work fine in
-    // other CI environments (such as Jenkins), but on Travis they're unreliable.
-    char *travis = getenv("TRAVIS");
-    if (travis) {
-        return;
-    }
-
     // Make sure the labels start out the way we expect (top is visible, bottom is not).
     SLElement *topLabel = [SLElement elementWithAccessibilityLabel:@"Top"];
     SLElement *bottomLabel = [SLElement elementWithAccessibilityLabel:@"Bottom"];
@@ -88,14 +94,6 @@ startDraggingSimple:
 /// This test demonstrates exactly what it means to drag between two points,
 /// in terms of the distance dragged.
 - (void)testDraggingPrecise {
-    // Do not run this test on Travis, because even very simple scrolling tests
-    // fail regularly on the Travis machines.  These tests seem to work fine in
-    // other CI environments (such as Jenkins), but on Travis they're unreliable.
-    char *travis = getenv("TRAVIS");
-    if (travis) {
-        return;
-    }
-
     CGFloat dragStartY = kTopLabelYOffset;
     CGFloat dragEndY = kBottomLabelYOffset;
 

--- a/Sources/Classes/Internal/SLTest+Internal.h
+++ b/Sources/Classes/Internal/SLTest+Internal.h
@@ -65,6 +65,32 @@
  */
 + (NSSet *)testCasesToRun;
 
+/**
+ Runs all test cases defined on the receiver's class,
+ and reports statistics about their execution.
+ 
+ See `SLTest (SLTestCase)` for a discussion of test case execution.
+ 
+ @param numCasesExecuted If this is non-`NULL`, on return, this will be set to
+ the number of test cases that were executed--which will be the number of test
+ cases defined by the receiver's class.
+ @param numCasesFailed If this is non-`NULL`, on return, this will be set to the
+ number of test cases that failed (the number of test cases that threw exceptions).
+ @param numCasesFailedUnexpectedly If this is non-`NULL`, on return, this will
+ be set to the number of test cases that failed unexpectedly (those test cases
+ that threw exceptions for other reasons than test assertion failures).
+ 
+ @return `YES` if the test successfully finished (all test cases were executed, regardless of their individual
+ success or failure), `NO` otherwise (an exception occurred in test case [set-up](-setUpTest) or [tear-down](-tearDownTest) ).
+ 
+ @warning If an exception occurs in test case set-up, the test's cases will be skipped.
+ Thus, the caller should use the values returned in `numCasesExecuted`, `numCasesFailed`,
+ and `numCasesFailedUnexpectedly` if and only if this method returns `YES`.
+ */
+- (BOOL)runAndReportNumExecuted:(NSUInteger *)numCasesExecuted
+                         failed:(NSUInteger *)numCasesFailed
+             failedUnexpectedly:(NSUInteger *)numCasesFailedUnexpectedly;
+
 @end
 
 

--- a/Sources/Classes/Internal/SLTestController+Internal.h
+++ b/Sources/Classes/Internal/SLTestController+Internal.h
@@ -42,7 +42,8 @@
  
  1. to those tests that [are concrete](+[SLTest isAbstract]),
  2. that [support the current platform](+[SLTest supportsCurrentPlatform]),
- 3. and that [are focused](+[SLTest isFocused]) (if any remaining are focused).
+ 3. that [support the current environment](+[SLTest supportsCurrentEnvironment]),
+ 4. and that [are focused](+[SLTest isFocused]) (if any remaining are focused).
  
  By sorting prior to filtering, the relative order of tests is maintained 
  regardless of focus.

--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -47,7 +47,7 @@
  
  Without modifying the argument to `-[SLTestController runTests:withCompletionBlock:]`, 
  tests may be conditionalized to run only in certain circumstances using APIs
- like `+isAbstract`, `+supportsCurrentPlatform`, and `+isFocused`.
+ like `+isAbstract`, `+supportsCurrentPlatform`, `+supportsCurrentEnvironment`, and `+isFocused`.
 
  @return All tests (`SLTest` subclasses) linked against the current target.
  */
@@ -88,13 +88,13 @@
 + (BOOL)isAbstract;
 
 /**
- Returns YES if this test has at least one test case which can be run
+ Returns YES if this test has at least one test case which should be run
  given the current device, screen, etc.
  
  Subclasses of `SLTest` should override this method if some run-time condition
- should determine whether or not all test cases should run. 
- Typical checks might include checking the user interface idiom (phone or pad) 
- of the current device, or checking the scale of the main screen.
+ concerning the current platform should determine whether or not all test cases
+ should be run. Typical checks might include checking the user interface idiom
+ (phone or pad) of the current device, or checking the scale of the main screen.
 
  As a convenience, test writers may specify the device type(s) on which a
  test can run by suffixing tests' names in the following fashion:
@@ -111,21 +111,22 @@
  appropriately and that there is at least one test case for which
  `+testCaseWithSelectorSupportsCurrentPlatform:` returns `YES`.
 
- If this method returns `NO`, none of this test's cases will run.
+ If this method returns `NO`, none of this test's cases will be run.
 
- @return `YES` if this class has test cases that can currently run, `NO` otherwise.
+ @return `YES` if this class has test cases that should be run on the current platform,
+ `NO` otherwise.
  
  @see +testCaseWithSelectorSupportsCurrentPlatform:
  */
 + (BOOL)supportsCurrentPlatform;
 
 /**
- Returns YES if this test case can be run given the current device, screen, etc.
+ Returns YES if this test case should be run given the current device, screen, etc.
  
- Subclasses of SLTest should override this method if they need to do any run-time
- checks to determine whether or not specific test cases can run. Typical checks
- might include checking the user interface idiom (phone or pad) of the current
- device, or checking the scale of the main screen.
+ Subclasses of `SLTest` should override this method if they need to do any run-time
+ checks to determine whether or not specific test cases should be run based on the current
+ platform. Typical checks might include checking the user interface idiom (phone or pad)
+ of the current device, or checking the scale of the main screen.
  
  As a convenience, test writers may specify the device type(s) on which a
  test case can run by suffixing test cases' names in the following fashion:
@@ -141,19 +142,77 @@
  The default implementation of this method checks that the selector is suffixed
  appropriately.
  
- @warning If the test does not support the current platform, that test's cases
+ @warning If the test does not support the current platform, its cases
  will not be run regardless of this method's return value.
  
  @param testCaseSelector A selector identifying a test case.
- @return `YES` if the test case can be run, `NO` otherwise.
+ 
+ @return `YES` if the test case should be run on the current platform, `NO` otherwise.
  
  @see +supportsCurrentPlatform
  */
 + (BOOL)testCaseWithSelectorSupportsCurrentPlatform:(SEL)testCaseSelector;
 
 /**
+ Returns YES if this test has at least one test case which can be run
+ given the environment from which the process was launched.
+ 
+ Subclasses of `SLTest` should override this method if some run-time condition
+ concerning the current environment should determine whether or not all test cases
+ should be run. A typical check would be to look for an environment variable specifying
+ which test cases should be run.
+ 
+ When running tests from Xcode, you can set environment variables by
+ [modifying your integration tests scheme](http://nshipster.com/launch-arguments-and-environment-variables/) .
+ When running `subliminal-test` from the command line, you can set environment variables
+ using the "-e" option. Environment variables and their values can then be retrieved
+ from the dictionary returned by `[[NSProcessInfo processInfo] environment]`.
+ 
+ The default implementation of this method checks that there is at least one test
+ case for which `+testCaseWithSelectorSupportsCurrentEnvironment:` returns `YES`.
+ 
+ If this method returns `NO`, none of this test's cases will be run.
+ 
+ @return `YES` if this class has test cases that should be run in the current
+ environment, `NO` otherwise.
+ 
+ @see +testCaseWithSelectorSupportsCurrentPlatform:
+ */
++ (BOOL)supportsCurrentEnvironment;
+
+/**
+ Returns YES if this test case can be run given the environment from which
+ the process was launched.
+ 
+ Subclasses of `SLTest` should override this method if they need to do any run-time
+ checks to determine whether or not specific test cases should be run based on the
+ current environment. A typical check would be to look for an environment variable
+ specifying which test cases should be run.
+ 
+ When running tests from Xcode, you can set environment variables by
+ [modifying your integration tests scheme](http://nshipster.com/launch-arguments-and-environment-variables/) .
+ When running `subliminal-test` from the command line, you can set environment variables
+ using the "-e" option. Environment variables and their values can then be retrieved
+ from the dictionary returned by `[[NSProcessInfo processInfo] environment]`.
+ 
+ The default implementation of this method returns `YES`--test cases will be run
+ regardless of environment.
+ 
+ @warning If the test does not support the current environment, its cases
+ will not be run regardless of this method's return value.
+ 
+ @param testCaseSelector A selector identifying a test case.
+ 
+ @return `YES` if the test case should be run in the current environment, `NO` otherwise.
+ 
+ @see +supportsCurrentEnvironment
+ */
++ (BOOL)testCaseWithSelectorSupportsCurrentEnvironment:(SEL)testCaseSelector;
+
+/**
  Returns YES if the test has at least one test case which is focused
- and which [supports the current platform](+testCaseWithSelectorSupportsCurrentPlatform:).
+ and which supports the current [platform](+testCaseWithSelectorSupportsCurrentPlatform:)
+ and [environment](+testCaseWithSelectorSupportsCurrentEnvironment:).
 
  When a test is run, if any of its test cases are focused, only those test cases will run.
  This may be useful when writing or debugging tests.
@@ -174,7 +233,7 @@
 
  @warning Focused test cases will not be run if their test is not run (e.g. if
  it is not included in the set of tests to be run, or if it does not support
- the current platform).
+ the current [platform](+supportsCurrentPlatform) or [environment](+supportsCurrentEnvironment)).
 
  @return `YES` if any test cases are focused and supports the current platform, 
  `NO` otherwise.

--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -268,8 +268,8 @@
  (_without_ spaces). If the variable is not set, this method will return `YES`.
  If the variable is set, this method will return `YES` if and only if:
  
- * the list contains one or more tags not prefixed with '-'; those tags
- [apply to this test case](+tagsForTestCaseWithSelector:); and the list does not
+ * the list contains one or more tags not prefixed with '-', those tags
+ [apply to this test case](+tagsForTestCaseWithSelector:), and the list does not
  contain any applicable tags prefixed with '-'; or if
  * the list contains _only_ tags prefixed with '-', and none of those tags
  apply to this test case.
@@ -282,10 +282,11 @@
  * (not set) -> `YES`
  * "FooTest" -> `YES` (because `-foo` is tagged with "FooTest")
  * "foo" -> `YES` (because `-foo` is tagged with "foo")
- * "-bar" -> `YES` (because `-foo` is not tagged with "bar")
- * "-foo" -> `NO` (because `-foo` is tagged with "foo")
  * "bar" -> `NO` (because `-foo` is not tagged with "bar")
+ * "-bar" -> `YES` (because `-foo` is not tagged with "bar")
  * "-bar,baz" -> `NO` (because `-foo` is not tagged with "baz")
+ * "-foo" -> `NO` (because `-foo` is tagged with "foo")
+ * "FooTest,-foo" -> `NO` (because `-foo` is tagged with "foo", even though it's tagged with "FooTest")
  
  It bears repeating that, by default, test cases inherit their test's [tags](+tags).
  Thus, all test cases of `FooTest` may be "selected" by setting `SL_TAGS` to "FooTest".

--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -213,37 +213,6 @@
  */
 + (NSUInteger)runGroup;
 
-#pragma mark - Running a Test
-/// ----------------------------------------
-/// @name Running a Test
-/// ----------------------------------------
-
-/**
- Runs all test cases defined on the receiver's class, 
- and reports statistics about their execution.
- 
- See `SLTest (SLTestCase)` for a discussion of test case execution.
- 
- @param numCasesExecuted If this is non-`NULL`, on return, this will be set to
- the number of test cases that were executed--which will be the number of test
- cases defined by the receiver's class.
- @param numCasesFailed If this is non-`NULL`, on return, this will be set to the
- number of test cases that failed (the number of test cases that threw exceptions).
- @param numCasesFailedUnexpectedly If this is non-`NULL`, on return, this will
- be set to the number of test cases that failed unexpectedly (those test cases
- that threw exceptions for other reasons than test assertion failures).
- 
- @return `YES` if the test successfully finished (all test cases were executed, regardless of their individual 
- success or failure), `NO` otherwise (an exception occurred in test case [set-up](-setUpTest) or [tear-down](-tearDownTest) ).
- 
- @warning If an exception occurs in test case set-up, the test's cases will be skipped.
- Thus, the caller should use the values returned in `numCasesExecuted`, `numCasesFailed`, 
- and `numCasesFailedUnexpectedly` if and only if this method returns `YES`.
- */
-- (BOOL)runAndReportNumExecuted:(NSUInteger *)numCasesExecuted
-                         failed:(NSUInteger *)numCasesFailed
-             failedUnexpectedly:(NSUInteger *)numCasesFailedUnexpectedly;
-
 @end
 
 

--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -120,8 +120,40 @@
 + (BOOL)supportsCurrentPlatform;
 
 /**
+ Returns YES if this test case can be run given the current device, screen, etc.
+ 
+ Subclasses of SLTest should override this method if they need to do any run-time
+ checks to determine whether or not specific test cases can run. Typical checks
+ might include checking the user interface idiom (phone or pad) of the current
+ device, or checking the scale of the main screen.
+ 
+ As a convenience, test writers may specify the device type(s) on which a
+ test case can run by suffixing test cases' names in the following fashion:
+ 
+ *  A test case whose name has the suffix "`_iPhone`," like "`testFoo_iPhone`",
+ will be executed only when `([[UIDevice currentDevice] userInterfaceIdiom] ==
+ UIUserInterfaceIdiomPhone)` is true.
+ *  A test case whose name has the suffix "`_iPad`" will be executed only
+ when the current device user interface idiom is `UIUserInterfaceIdiomPad`.
+ *  A test case whose name has neither the "`_iPhone`" nor the "`_iPad`"
+ suffix will be executed on all devices regardless of the user interface idiom.
+ 
+ The default implementation of this method checks that the selector is suffixed
+ appropriately.
+ 
+ @warning If the test does not support the current platform, that test's cases
+ will not be run regardless of this method's return value.
+ 
+ @param testCaseSelector A selector identifying a test case.
+ @return `YES` if the test case can be run, `NO` otherwise.
+ 
+ @see +supportsCurrentPlatform
+ */
++ (BOOL)testCaseWithSelectorSupportsCurrentPlatform:(SEL)testCaseSelector;
+
+/**
  Returns YES if the test has at least one test case which is focused
- and which can run on the current platform.
+ and which [supports the current platform](+testCaseWithSelectorSupportsCurrentPlatform:).
 
  When a test is run, if any of its test cases are focused, only those test cases will run.
  This may be useful when writing or debugging tests.
@@ -144,7 +176,7 @@
  it is not included in the set of tests to be run, or if it does not support
  the current platform).
 
- @return `YES` if any test cases are focused and can be run on the current platform, 
+ @return `YES` if any test cases are focused and supports the current platform, 
  `NO` otherwise.
 
  @see -[SLTestController runTests:usingSeed:withCompletionBlock:]
@@ -240,38 +272,6 @@
 /// ----------------------------------------
 /// @name Running Test Cases
 /// ----------------------------------------
-
-/**
- Returns YES if this test case can be run given the current device, screen, etc.
-
- Subclasses of SLTest should override this method if they need to do any run-time 
- checks to determine whether or not specific test cases can run. Typical checks 
- might include checking the user interface idiom (phone or pad) of the current 
- device, or checking the scale of the main screen.
-
- As a convenience, test writers may specify the device type(s) on which a 
- test case can run by suffixing test cases' names in the following fashion:
-
- *  A test case whose name has the suffix "`_iPhone`," like "`testFoo_iPhone`",
-    will be executed only when `([[UIDevice currentDevice] userInterfaceIdiom] ==
-    UIUserInterfaceIdiomPhone)` is true.
- *  A test case whose name has the suffix "`_iPad`" will be executed only
-    when the current device user interface idiom is `UIUserInterfaceIdiomPad`.
- *  A test case whose name has neither the "`_iPhone`" nor the "`_iPad`"
-    suffix will be executed on all devices regardless of the user interface idiom.
-
- The default implementation of this method checks that the selector is suffixed 
- appropriately.
- 
- @warning If the test does not support the current platform, that test's cases
- will not be run regardless of this method's return value.
-
- @param testCaseSelector A selector identifying a test case.
- @return `YES` if the test case can be run, `NO` otherwise.
- 
- @see +supportsCurrentPlatform
- */
-+ (BOOL)testCaseWithSelectorSupportsCurrentPlatform:(SEL)testCaseSelector;
 
 /**
  Called before any test cases are run.

--- a/Sources/Classes/SLTest.h
+++ b/Sources/Classes/SLTest.h
@@ -33,9 +33,9 @@
  */
 @interface SLTest : NSObject
 
-#pragma mark - Retrieving Tests to Run
+#pragma mark - Identifying Tests to Run
 /// ----------------------------------------
-/// @name Retrieving Tests to Run
+/// @name Identifying Tests to Run
 /// ----------------------------------------
 
 /**
@@ -52,6 +52,67 @@
  @return All tests (`SLTest` subclasses) linked against the current target.
  */
 + (NSSet *)allTests;
+
+/**
+ Returns tests linked against the current target [tagged](+tags)
+ with one or more of the tags specified in _tags_,
+ which tests are not tagged with any '-'-prefixed tags specified in _tags_.
+ 
+ Calling this method with a set containing `[ "foo", "bar", "-baz" ]`, for instance,
+ would return a set containing all tests that were tagged with "foo" and/or "bar"
+ and were _not_ tagged with "baz".
+ 
+ Calling this method with a set containing _only_ tags prefixed with '-' returns
+ a set comprising _all_ tests except for those tagged with the '-'-prefixed tags.
+ 
+ @param tags A set of tags, which may optionally be prefixed with '-'
+ as described in the discussion.
+
+ @return All tests (`SLTest` subclasses) linked against the current target
+ which are [tagged](+tags) with one or more of the tags specified in _tags_
+ and are _not_ tagged with any of the '-'-prefixed tags specified in _tags_.
+ */
++ (NSSet *)testsWithTags:(NSSet *)tags;
+
+/**
+ One or more strings that you can use to identify this test.
+
+ By default, a test is tagged with the (unfocused)[+isFocused] name of its class
+ as well as its [run group](+runGroup) (as a string).
+ 
+ You might add tags to describe the functionality tested by this class
+ or to divide tests into separate test suites. Your implementation of this method
+ should call `super` and add to, rather than replace, the tag set.
+
+ Tags are case-insensitive. Tags must not begin with '-' --see `+testsWithTags:`.
+
+ @return A set of tags describing this test.
+
+ @see +testsWithTags:
+ @see +tagsForTestCaseWithSelector:
+ */
++ (NSSet *)tags;
+
+/**
+ One or more strings that you can use to identify this test case.
+
+ By default, a test case inherits its test's [tags](+tags), and is also tagged
+ with the (unfocused)[+isFocused) form of its selector.
+
+ You might add tags to describe the functionality tested by this test case
+ or to divide tests into separate test suites. Your implementation of this method
+ should call `super` and add to, rather than replace, the tag set.
+ 
+ Tags are case-insensitive. Tags must not begin with '-' --see `+testsWithTags:`.
+
+ @param testCaseSelector A selector identifying a test case.
+ 
+ @return A set of tags describing this test case.
+ 
+ @see +testsWithTags:
+ @see +tags
+ */
++ (NSSet *)tagsForTestCaseWithSelector:(SEL)testCaseSelector;
 
 /**
  Returns the `SLTest` subclass with the specified name.
@@ -176,7 +237,7 @@
  @return `YES` if this class has test cases that should be run in the current
  environment, `NO` otherwise.
  
- @see +testCaseWithSelectorSupportsCurrentPlatform:
+ @see +testCaseWithSelectorSupportsCurrentEnvironment:
  */
 + (BOOL)supportsCurrentEnvironment;
 

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -63,7 +63,32 @@ static int __lastKnownLineNumber;
         free(classes);
     }
     
-    return tests;
+    return [tests copy];
+}
+
++ (NSSet *)testsWithTags:(NSSet *)tags {
+    NSMutableSet *inclusionTags = [tags mutableCopy];
+    NSMutableSet *exclusionTags = [[NSMutableSet alloc] initWithCapacity:[tags count]];
+    for (NSString *tag in tags) {
+        if ([tag hasPrefix:@"-"]) {
+            [inclusionTags removeObject:tag];
+            [exclusionTags addObject:[tag substringFromIndex:1]];
+        }
+    }
+    
+    NSMutableSet *tests = [[self allTests] mutableCopy];
+    if ([inclusionTags count]) [tests filterUsingPredicate:[NSPredicate predicateWithFormat:@"ANY SELF.tags in %@", inclusionTags]];
+    if ([exclusionTags count]) [tests filterUsingPredicate:[NSPredicate predicateWithFormat:@"NONE SELF.tags in %@", exclusionTags]];
+    return [tests copy];
+}
+
++ (NSSet *)tags {
+    NSString *name = NSStringFromClass([self class]);
+    if ([[name lowercaseString] hasPrefix:SLTestFocusPrefix]) {
+        name = [name substringFromIndex:[SLTestFocusPrefix length]];
+    }
+    NSString *runGroup = [NSString stringWithFormat:@"%lu", (unsigned long)[self runGroup]];
+    return [NSSet setWithObjects:name, runGroup, nil];
 }
 
 + (Class)testNamed:(NSString *)name {

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -87,7 +87,10 @@ static int __lastKnownLineNumber;
     for (NSString *testCaseName in [self focusedTestCases]) {
         // pass the unfocused selector, as focus is temporary and shouldn't require modifying the test infrastructure
         SEL unfocusedTestCaseSelector = NSSelectorFromString([self unfocusedTestCaseName:testCaseName]);
-        if ([self testCaseWithSelectorSupportsCurrentPlatform:unfocusedTestCaseSelector]) return YES;
+        if ([self testCaseWithSelectorSupportsCurrentPlatform:unfocusedTestCaseSelector] &&
+            [self testCaseWithSelectorSupportsCurrentEnvironment:unfocusedTestCaseSelector]) {
+            return YES;
+        }
     }
     return NO;
 }
@@ -129,6 +132,19 @@ static int __lastKnownLineNumber;
     UIUserInterfaceIdiom userInterfaceIdiom = [[UIDevice currentDevice] userInterfaceIdiom];
     if ([testCaseName hasSuffix:@"_iPad"]) return (userInterfaceIdiom == UIUserInterfaceIdiomPad);
     if ([testCaseName hasSuffix:@"_iPhone"]) return (userInterfaceIdiom == UIUserInterfaceIdiomPhone);
+    return YES;
+}
+
++ (BOOL)supportsCurrentEnvironment {
+    for (NSString *testCaseName in [self testCases]) {
+        // pass the unfocused selector, as focus is temporary and shouldn't require modifying the test infrastructure
+        SEL unfocusedTestCaseSelector = NSSelectorFromString([self unfocusedTestCaseName:testCaseName]);
+        if ([self testCaseWithSelectorSupportsCurrentEnvironment:unfocusedTestCaseSelector]) return YES;
+    }
+    return NO;
+}
+
++ (BOOL)testCaseWithSelectorSupportsCurrentEnvironment:(SEL)testCaseSelector {
     return YES;
 }
 
@@ -229,7 +245,8 @@ static int __lastKnownLineNumber;
     return [baseTestCases filteredSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
         // pass the unfocused selector, as focus is temporary and shouldn't require modifying the test infrastructure
         SEL unfocusedTestCaseSelector = NSSelectorFromString([self unfocusedTestCaseName:evaluatedObject]);
-        return [self testCaseWithSelectorSupportsCurrentPlatform:unfocusedTestCaseSelector];
+        return ([self testCaseWithSelectorSupportsCurrentPlatform:unfocusedTestCaseSelector] &&
+                [self testCaseWithSelectorSupportsCurrentEnvironment:unfocusedTestCaseSelector]);
     }]];
 }
 

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -113,6 +113,15 @@ static int __lastKnownLineNumber;
     return testSupportsCurrentDevice;
 }
 
++ (BOOL)testCaseWithSelectorSupportsCurrentPlatform:(SEL)testCaseSelector {
+    NSString *testCaseName = NSStringFromSelector(testCaseSelector);
+    
+    UIUserInterfaceIdiom userInterfaceIdiom = [[UIDevice currentDevice] userInterfaceIdiom];
+    if ([testCaseName hasSuffix:@"_iPad"]) return (userInterfaceIdiom == UIUserInterfaceIdiomPad);
+    if ([testCaseName hasSuffix:@"_iPhone"]) return (userInterfaceIdiom == UIUserInterfaceIdiomPhone);
+    return YES;
+}
+
 + (NSUInteger)runGroup {
     return 1;
 }
@@ -221,15 +230,6 @@ static int __lastKnownLineNumber;
     }
     return testCase;
 }
-
-+ (BOOL)testCaseWithSelectorSupportsCurrentPlatform:(SEL)testCaseSelector {
-    NSString *testCaseName = NSStringFromSelector(testCaseSelector);
-    
-    UIUserInterfaceIdiom userInterfaceIdiom = [[UIDevice currentDevice] userInterfaceIdiom];
-    if ([testCaseName hasSuffix:@"_iPad"]) return (userInterfaceIdiom == UIUserInterfaceIdiomPad);
-    if ([testCaseName hasSuffix:@"_iPhone"]) return (userInterfaceIdiom == UIUserInterfaceIdiomPhone);
-    return YES;
- }
 
 - (BOOL)runAndReportNumExecuted:(NSUInteger *)numCasesExecuted
                          failed:(NSUInteger *)numCasesFailed

--- a/Sources/Classes/SLTest.m
+++ b/Sources/Classes/SLTest.m
@@ -110,7 +110,17 @@ static int __lastKnownLineNumber;
         testClass = [testClass superclass];
     }
 
-    return testSupportsCurrentDevice;
+    BOOL aTestCaseSupportsCurrentPlatform = NO;
+    for (NSString *testCaseName in [self testCases]) {
+        // pass the unfocused selector, as focus is temporary and shouldn't require modifying the test infrastructure
+        SEL unfocusedTestCaseSelector = NSSelectorFromString([self unfocusedTestCaseName:testCaseName]);
+        if ([self testCaseWithSelectorSupportsCurrentPlatform:unfocusedTestCaseSelector]) {
+            aTestCaseSupportsCurrentPlatform = YES;
+            break;
+        }
+    }
+    
+    return testSupportsCurrentDevice && aTestCaseSupportsCurrentPlatform;
 }
 
 + (BOOL)testCaseWithSelectorSupportsCurrentPlatform:(SEL)testCaseSelector {

--- a/Sources/Classes/SLTestController.h
+++ b/Sources/Classes/SLTestController.h
@@ -81,7 +81,8 @@
  If any tests fail, the test controller will log the seed that was used,
  so that the run order may be reproduced by invoking this method with that seed.
 
- Tests must [support the current platform](+[SLTest supportsCurrentPlatform]) in order to be run.
+ Tests must support the current [platform](+[SLTest supportsCurrentPlatform])
+ and [environment](+[SLTest supportsCurrentEnvironment]) in order to be run.
  If any tests [are focused](+[SLTest isFocused]), only those tests will be run.
  
  When using a given seed, tests execute in the same relative order regardless of focus.

--- a/Sources/Classes/SLTestController.m
+++ b/Sources/Classes/SLTestController.m
@@ -190,11 +190,15 @@ u_int32_t random_uniform(u_int32_t upperBound) {
         [testsToRun addObjectsFromArray:group];
     }
 
-    // now filter the tests to run: only run tests that are concrete...
-    [testsToRun filterUsingPredicate:[NSPredicate predicateWithFormat:@"isAbstract == NO"]];
-
-    // ...that support the current platform...
-    [testsToRun filterUsingPredicate:[NSPredicate predicateWithFormat:@"supportsCurrentPlatform == YES"]];
+    // now filter the tests to run:
+    [testsToRun filterUsingPredicate:[NSCompoundPredicate andPredicateWithSubpredicates:@[
+        // only run tests that are concrete...
+        [NSPredicate predicateWithFormat:@"isAbstract == NO"],
+        // ...that support the current platform...
+        [NSPredicate predicateWithFormat:@"supportsCurrentPlatform == YES"],
+        // ...that support the current environment...
+        [NSPredicate predicateWithFormat:@"supportsCurrentEnvironment == YES"]
+    ]]];
 
     // ...and that are focused (if any remaining are focused)
     NSMutableArray *focusedTests = [testsToRun mutableCopy];

--- a/Sources/Classes/SLTestController.m
+++ b/Sources/Classes/SLTestController.m
@@ -334,6 +334,10 @@ u_int32_t random_uniform(u_int32_t upperBound) {
     if (_runningWithFocus) {
         SLLog(@"Focusing on test cases in specific tests: %@.", [_testsToRun componentsJoinedByString:@","]);
     }
+    NSString *tags = [[[[NSProcessInfo processInfo] environment][@"SL_TAGS"] componentsSeparatedByString:@","] componentsJoinedByString:@", "];
+    if (tags) {
+        SLLog(@"Running test cases described by tags: %@.", tags);
+    }
 
     [self warnIfAccessibilityInspectorIsEnabled];
 
@@ -402,6 +406,8 @@ u_int32_t random_uniform(u_int32_t upperBound) {
     if (_runningWithFocus) {
         [[SLLogger sharedLogger] logWarning:@"This was a focused run. Fewer test cases may have run than normal."];
     }
+    // don't show a warning about `SL_TAGS` being set
+    // because tagging is intentional and allowed, even in CI environments
 
     if (_completionBlock) dispatch_sync(dispatch_get_main_queue(), _completionBlock);
 

--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -207,9 +207,17 @@ case $1 in
 		CURRENT_ARG=LOGIN_PASSWORD
 		shift 1;;
 
-    -*)	
-		echo "Unrecognized argument: $1"
-    	print_usage_and_fail;;
+	-*)
+		# Permit environment variable values to begin with "-"
+		if [[ "$CURRENT_ARG" == "-e "* ]]; then
+			# Append "-e <variable_name> <variable_value>" to the environment string
+			ENV_STR+=" $CURRENT_ARG $1"
+			unset CURRENT_ARG
+		else
+			echo "Unrecognized argument: $1"
+	  	print_usage_and_fail
+	  fi
+	  shift;;
 
 	# Set value for argument (unless end of command)
 	*)
@@ -221,7 +229,8 @@ case $1 in
 				# Add variable name to the placeholder
 				CURRENT_ARG="-e $1"
 			elif [[ "$CURRENT_ARG" == "-e "* ]]; then
-				# Append "-e <variable_name> <variable_value>" to the environment string
+				# Append "-e <variable_name> <variable_value>" to the environment string.
+				# Keep this logic in sync with the `-*)` case above
 				ENV_STR+=" $CURRENT_ARG $1"
 				unset CURRENT_ARG
 			else

--- a/Supporting Files/CI/subliminal-test
+++ b/Supporting Files/CI/subliminal-test
@@ -187,7 +187,7 @@ case $1 in
 		shift 1;;
 
 	# Set argument, wait for value
-    -project|-workspace|-prebuilt_app|-sim_device|-hw_id|-build_tool|-scheme|-configuration|-sdk|-replacement_bundle_id|-sim_version|-timeout|-output|-e)
+	-project|-workspace|-prebuilt_app|-sim_device|-hw_id|-build_tool|-scheme|-configuration|-sdk|-replacement_bundle_id|-sim_version|-timeout|-output|-e)
 		if [[ -n "$CURRENT_ARG" ]]; then
 			echo "Missing value for argument: $CURRENT_ARG"
 			print_usage_and_fail
@@ -198,7 +198,7 @@ case $1 in
 			# Variables (apart from env vars) are capitalized in this script
 			*)	CURRENT_ARG=`echo ${1#-} | tr [[:lower:]] [[:upper:]]`;;
 		esac
-	    shift 1;;
+		shift 1;;
 
 	-login_password)
 		echo $LOGIN_PASSWORD_DEPRECATION_MESSAGE
@@ -215,7 +215,7 @@ case $1 in
 	*)
 		if [[ -n "$1" ]]; then
 			if [[ -z "$CURRENT_ARG" ]]; then
-				echo "Value \"$1\" is missing argument"
+				echo "Value \"$1\" does not correspond to an option"
 				print_usage_and_fail
 			elif [[ "$CURRENT_ARG" == "-e" ]]; then
 				# Add variable name to the placeholder
@@ -226,7 +226,7 @@ case $1 in
 				unset CURRENT_ARG
 			else
 				eval $CURRENT_ARG=\"$1\"
-				unset CURRENT_ARG;
+				unset CURRENT_ARG
 			fi
 		else
 			# end of command

--- a/Unit Tests/SLTestControllerTests.m
+++ b/Unit Tests/SLTestControllerTests.m
@@ -25,6 +25,7 @@
 #import <Subliminal/SLTerminal.h>
 #import <OCMock/OCMock.h>
 
+#import "SLTest+Internal.h"
 #import "TestUtilities.h"
 #import "SharedSLTests.h"
 

--- a/Unit Tests/SharedSLTests.h
+++ b/Unit Tests/SharedSLTests.h
@@ -223,3 +223,12 @@
 
 @interface TestWithTagBBBandCCC : SLTest
 @end
+
+
+@interface TestWithSomeTaggedTestCases : SLTest
+
+- (void)testCaseWithTagAAAandCCC;
+- (void)testCaseWithTagBBBandCCC;
+- (void)testOtherCase;
+
+@end

--- a/Unit Tests/SharedSLTests.h
+++ b/Unit Tests/SharedSLTests.h
@@ -10,10 +10,10 @@
 
 /*
  All SLTests linked against the Unit Tests target should be defined here,
- for discoverability, as -[SLTestTests testAllTestsReturnsExpected] depends 
+ for discoverability, as `-[SLTestTests testAllTestsReturnsExpected]` depends
  on knowing what tests there are.
  
- If you add a new SLTest, please remember to update -[SLTestTests testAllTestsReturnsExpected].
+ If you add a new SLTest, please remember to update `-[SLTestTests testAllTestsReturnsExpected]`.
  */
 
 @interface TestWithSomeTestCases : SLTest
@@ -214,4 +214,12 @@
 
 - (void)testFoo;
 
+@end
+
+
+@interface TestWithTagAAAandCCC : SLTest
+@end
+
+
+@interface TestWithTagBBBandCCC : SLTest
 @end

--- a/Unit Tests/SharedSLTests.h
+++ b/Unit Tests/SharedSLTests.h
@@ -66,6 +66,21 @@
 @end
 
 
+@interface TestNotSupportingCurrentEnvironment : SLTest
+
+- (void)testFoo;
+
+@end
+
+
+@interface TestWithEnvironmentSpecificTestCases : SLTest
+
+- (void)testFoo;
+- (void)testCaseNotSupportingCurrentEnvironment;
+
+@end
+
+
 @interface AbstractTestWhichSupportsOnly_iPad : SLTest
 @end
 
@@ -108,6 +123,14 @@
 @end
 
 
+@interface TestWithAFocusedEnvironmentSpecificTestCase : SLTest
+
+- (void)testFoo;
+- (void)focus_testBar;
+
+@end
+
+
 @interface Focus_TestThatIsFocused : SLTest
 
 - (void)testFoo;
@@ -124,6 +147,13 @@
 
 
 @interface Focus_TestThatIsFocusedButDoesntSupportCurrentPlatform : SLTest
+
+- (void)testOne;
+
+@end
+
+
+@interface Focus_TestThatIsFocusedButDoesntSupportCurrentEnvironment : SLTest
 
 - (void)testOne;
 

--- a/Unit Tests/SharedSLTests.m
+++ b/Unit Tests/SharedSLTests.m
@@ -271,3 +271,24 @@
 }
 
 @end
+
+
+@implementation TestWithSomeTaggedTestCases
+
++ (NSSet *)tagsForTestCaseWithSelector:(SEL)testCaseSelector {
+    NSMutableSet *tags = [[super tagsForTestCaseWithSelector:testCaseSelector] mutableCopy];
+    
+    if (testCaseSelector == @selector(testCaseWithTagAAAandCCC)) {
+        [tags addObjectsFromArray:@[ @"AAA", @"CCC" ]];
+    } else if (testCaseSelector == @selector(testCaseWithTagBBBandCCC)) {
+        [tags addObjectsFromArray:@[ @"BBB", @"CCC" ]];
+    }
+    
+    return [tags copy];
+}
+
+- (void)testCaseWithTagAAAandCCC {}
+- (void)testCaseWithTagBBBandCCC {}
+- (void)testOtherCase {}
+
+@end

--- a/Unit Tests/SharedSLTests.m
+++ b/Unit Tests/SharedSLTests.m
@@ -253,3 +253,21 @@
 - (void)testFoo {}
 
 @end
+
+
+@implementation TestWithTagAAAandCCC
+
++ (NSSet *)tags {
+    return [[super tags] setByAddingObjectsFromArray:@[ @"AAA", @"CCC" ]];
+}
+
+@end
+
+
+@implementation TestWithTagBBBandCCC
+
++ (NSSet *)tags {
+    return [[super tags] setByAddingObjectsFromArray:@[ @"BBB", @"CCC" ]];
+}
+
+@end

--- a/Unit Tests/SharedSLTests.m
+++ b/Unit Tests/SharedSLTests.m
@@ -69,6 +69,30 @@
 @end
 
 
+@implementation TestNotSupportingCurrentEnvironment
+
++ (BOOL)supportsCurrentEnvironment {
+    return NO;
+}
+
+- (void)testFoo {}
+
+@end
+
+
+@implementation TestWithEnvironmentSpecificTestCases
+
++ (BOOL)testCaseWithSelectorSupportsCurrentEnvironment:(SEL)testCaseSelector {
+    return ([super testCaseWithSelectorSupportsCurrentEnvironment:testCaseSelector] &&
+            (testCaseSelector != @selector(testCaseNotSupportingCurrentEnvironment)));
+}
+
+- (void)testFoo {}
+- (void)testCaseNotSupportingCurrentEnvironment {}
+
+@end
+
+
 @implementation AbstractTestWhichSupportsOnly_iPad
 @end
 
@@ -111,6 +135,20 @@
 @end
 
 
+@implementation TestWithAFocusedEnvironmentSpecificTestCase
+
++ (BOOL)testCaseWithSelectorSupportsCurrentEnvironment:(SEL)testCaseSelector {
+    return ([super testCaseWithSelectorSupportsCurrentEnvironment:testCaseSelector] &&
+            // this method is invoked with the unfocused selector
+            (testCaseSelector != @selector(testBar)));
+}
+
+- (void)testFoo {}
+- (void)focus_testBar {}
+
+@end
+
+
 @implementation Focus_TestThatIsFocused
 
 - (void)testFoo {}
@@ -129,6 +167,17 @@
 @implementation Focus_TestThatIsFocusedButDoesntSupportCurrentPlatform
 
 + (BOOL)supportsCurrentPlatform {
+    return NO;
+}
+
+- (void)testOne {}
+
+@end
+
+
+@implementation Focus_TestThatIsFocusedButDoesntSupportCurrentEnvironment
+
++ (BOOL)supportsCurrentEnvironment {
     return NO;
 }
 


### PR DESCRIPTION
Delivers the following features:
- tests and test cases can be tagged, with sensible defaults (test/test case names)
- `+[SLTest testsWithTags:]` allows a subset of tests to be selected while debugging
- the `SL_TAGS` environment variable allows a subset of tests and/or test cases to be selected in CI
- tests/test cases can be excluded by prefixing tags with "-"
- tests and test cases can respond to additional environment variables by overriding `+supportsCurrentEnvironment` and `+testCaseWithSelectorSupportsCurrentEnvironment:`

Many thanks to all (@jazzychad, @qiffp, @maxgabriel, @mrsamuelkim) who have weighed in on this topic. I think that this solution is general purpose enough to encompass the majority of your use cases.

In particular, it allows particular tests _or_ groups of tests to be selected, because tests are automatically tagged with their names; it does not interfere with the focus mechanism; it does not require that tagging is exhaustive, because tags can be excluded; and not only tests but also test cases can be tagged, using the same mechanism.
