### PR TITLE
Add a class property for the default value for SLElement's shouldDoubleCheckValidity

### DIFF
--- a/Sources/Classes/UIAutomation/User Interface Elements/SLElement.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLElement.h
@@ -207,4 +207,11 @@ extern UIAccessibilityTraits SLUIAccessibilityTraitAny;
  */
 @property (nonatomic) BOOL shouldDoubleCheckValidity;
 
+/**
+ The shouldDoubleCheckValidity BOOL defaults to NO, but this allows making double checking for the existence
+ of elements the default behavior for newly created SLElement objects, essentially making it opt-out instead
+ of opt-in.
+ */
++ (void)setDefaultForDoubleCheckValidity:(BOOL)shouldDoubleCheckValidity;
+
 @end

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLElement.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLElement.m
@@ -41,6 +41,8 @@ UIAccessibilityTraits SLUIAccessibilityTraitAny = 0;
     BOOL _shouldDoubleCheckValidity;
 }
 
+static BOOL defaultForShouldDoubleCheckValidity;
+
 + (void)load {
     // We create a unique `UIAccessibilityTraits` mask
     // from a combination of traits that should never occur in reality.
@@ -121,11 +123,16 @@ UIAccessibilityTraits SLUIAccessibilityTraitAny = 0;
     } description:@"any element"];
 }
 
++ (void)setDefaultForDoubleCheckValidity:(BOOL)shouldDoubleCheckValidity {
+    defaultForShouldDoubleCheckValidity = shouldDoubleCheckValidity;
+}
+
 - (instancetype)initWithPredicate:(BOOL (^)(NSObject *))predicate description:(NSString *)description {
     self = [super init];
     if (self) {
         _matchesObject = predicate;
         _description = [description copy];
+        _shouldDoubleCheckValidity = defaultForShouldDoubleCheckValidity;
     }
     return self;
 }


### PR DESCRIPTION
We'd like to turn on shouldDoubleCheckValidity all the time, and this seemed like the most straightforward way to expose this functionality. Turning it on has helped with automation reliability a bit. I honestly don't see an issue with having this running all the time, but that's your call.
