### PR TITLE
When contained in a UITableView, UIControls which contain any control will not be filtered (fixes #260)

### DIFF
--- a/Integration Tests/SLIntegrationTestsAppDelegate.m
+++ b/Integration Tests/SLIntegrationTestsAppDelegate.m
@@ -110,6 +110,7 @@
     }
 
     // Otherwise, run the tests
+    [[SLTestController sharedTestController] setShouldWaitToStartTesting:YES];
     [[SLTestController sharedTestController] runTests:[NSSet setWithArray:_tests] withCompletionBlock:nil];
 }
 

--- a/Integration Tests/SLIntegrationTestsAppDelegate.m
+++ b/Integration Tests/SLIntegrationTestsAppDelegate.m
@@ -110,7 +110,6 @@
     }
 
     // Otherwise, run the tests
-    [[SLTestController sharedTestController] setShouldWaitToStartTesting:YES];
     [[SLTestController sharedTestController] runTests:[NSSet setWithArray:_tests] withCompletionBlock:nil];
 }
 

--- a/Integration Tests/Tests/SLTextFieldTest.m
+++ b/Integration Tests/Tests/SLTextFieldTest.m
@@ -21,7 +21,6 @@
 //
 
 #import "SLIntegrationTest.h"
-#import <Subliminal/SLTerminal.h>
 
 @interface SLTextFieldTest : SLIntegrationTest
 
@@ -37,50 +36,8 @@
     return @"SLTextFieldTestViewController";
 }
 
-- (void)testDidEncounterFailure:(SLTestFailure *)failure;
-{
-    SLLog(@"[EXCEPTION STACK] %@", [failure.exception callStackSymbols]);
-    [self _logViewHierarchy];
-    [self _logUIAccessibilityHierarchy];
-    [self _dumpFullElementTree];
-    SLLog(@"TEST FAILURE ENCOUNTERED!");
-
-}
-
-- (void)_logViewHierarchy;
-{
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        NSArray *windows = [[UIApplication sharedApplication] windows];
-        UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
-        NSUInteger keyWindowIndex = [windows indexOfObject:keyWindow];
-
-        if (keyWindowIndex == NSNotFound) {
-            SLLogAsync(@"[NON-APP KEY WINDOW] %@", [keyWindow slRecursiveAccessibilityDescription]);
-        } else {
-            for (NSUInteger windowIndex = keyWindowIndex; windowIndex < [windows count]; windowIndex++) {
-                SLLogAsync(@"[APP KEY WINDOW #%lu] %@", (unsigned long)windowIndex, [windows[windowIndex] slRecursiveAccessibilityDescription]);
-            }
-        }
-    });
-}
-
-- (void)_logUIAccessibilityHierarchy;
-{
-    [[SLTerminal sharedTerminal] eval:@"UIATarget.localTarget().logElementTree()"];
-}
-
-- (void)_dumpFullElementTree;
-{
-    [SLTestController logFullySwizzledUIAElementTree];
-}
-
 - (void)setUpTestCaseWithSelector:(SEL)testSelector {
     [super setUpTestCaseWithSelector:testSelector];
-
-    if (testSelector == @selector(testSetTextWithinTableViewCellUnderControl)) {
-        _textField = [SLTextField elementWithAccessibilityIdentifier:@"text field"];
-        return;
-    }
 
     if (testSelector == @selector(testSetText) ||
         testSelector == @selector(testSetTextWithinTableViewCell) ||
@@ -90,7 +47,8 @@
         testSelector == @selector(testSetTextWhenFieldClearsOnBeginEditing) ||
         testSelector == @selector(testGetText) ||
         testSelector == @selector(testDoNotMatchEditorAccessibilityObjects) ||
-        testSelector == @selector(testClearTextButton)) {
+        testSelector == @selector(testClearTextButton) ||
+        testSelector == @selector(testSetTextWithinTableViewCellUnderControl)) {
         _textField = [SLTextField elementWithAccessibilityLabel:@"test element"];
     } else if (testSelector == @selector(testMatchesSearchBarTextField) ||
                testSelector == @selector(testSetSearchBarText) ||
@@ -119,12 +77,10 @@
     SLAssertTrue([SLAskApp(text) isEqualToString:expectedText], @"Text was not set to expected value.");
 }
 
-- (void)focus_testSetTextWithinTableViewCellUnderControl {
+- (void)testSetTextWithinTableViewCellUnderControl {
     NSString *const expectedText = @"Fooness";
-    _textField = [SLElement elementWithAccessibilityIdentifier:@"text field"];
-//    SLButton *button = [SLButton elementWithAccessibilityIdentifier:@"thebutton"];
-//    SLAssertNoThrow([UIAelement([button tap], @"Should not have thrown.");
-    SLAssertNoThrow(/*[UIAElement(_textField) setText:expectedText]*/[UIAElement(_textField) tap], @"Should not have thrown.");
+    SLAssertNoThrow([UIAElement(_textField) setText:expectedText], @"Should not have thrown.");
+    SLAssertNoThrow([UIAElement(_textField) tap], @"Should not have thrown.");
     SLAssertTrue([SLAskApp(text) isEqualToString:expectedText], @"Text was not set to expected value.");
 }
 

--- a/Integration Tests/Tests/SLTextFieldTestViewController.m
+++ b/Integration Tests/Tests/SLTextFieldTestViewController.m
@@ -42,6 +42,7 @@
 
     if (testCase == @selector(testSetText) ||
         testCase == @selector(testSetTextWithinTableViewCell) ||
+        testCase == @selector(testSetTextWithinTableViewCellUnderControl) ||
         testCase == @selector(testSetTextCanHandleTapHoldCharacters) ||
         testCase == @selector(testSetTextClearsCurrentText) ||
         testCase == @selector(testSetTextClearsCurrentTextWithinTableViewCell) ||
@@ -59,6 +60,14 @@
             _tableView = [[UITableView alloc] initWithFrame:(CGRect){CGPointZero, CGSizeMake(320.0f, 44.0f)}];
             _tableView.dataSource = self;
             [view addSubview:_tableView];
+        } else if (testCase == @selector(testSetTextWithinTableViewCellUnderControl)) {
+            UIControl *control = [[UIControl alloc] initWithFrame:view.bounds];
+            control.userInteractionEnabled = YES;
+            control.accessibilityIdentifier = @"text field";
+//            _textField.userInteractionEnabled = YES;
+            [control addSubview:_textField];
+            [view addSubview:control];
+//            [view addSubview:_textField];
         } else {
             [view addSubview:_textField];
         }
@@ -161,6 +170,7 @@
     NSString *text;
     if (self.testCase == @selector(testSetText) ||
         self.testCase == @selector(testSetTextWithinTableViewCell) ||
+        self.testCase == @selector(testSetTextWithinTableViewCellUnderControl) || 
         self.testCase == @selector(testSetTextCanHandleTapHoldCharacters) ||
         self.testCase == @selector(testSetTextClearsCurrentText) ||
         self.testCase == @selector(testSetTextClearsCurrentTextWithinTableViewCell) ||
@@ -201,7 +211,28 @@
     _textField.textColor = [UIColor blackColor];
     [_textField becomeFirstResponder];
 
-    [tableViewCell.contentView addSubview:_textField];
+    if (self.testCase == @selector(testSetTextWithinTableViewCellUnderControl)) {
+        UIControl *control = [[UIControl alloc] initWithFrame:self.view.bounds];
+        control.userInteractionEnabled = NO;
+
+        UITextField *field = [[UITextField alloc] initWithFrame:CGRectMake(10, 5, 25, 20)];
+
+        field.placeholder = @"FOO!";
+        field.accessibilityIdentifier = @"text field";
+        field.userInteractionEnabled = YES;
+
+//        UIButton *btn = [UIButton buttonWithType:UIButtonTypeInfoDark];
+//        [btn setFrame:CGRectMake(80, 0, 20, 20)];
+//        [btn setBackgroundColor:[UIColor blueColor]];
+//        [btn setAccessibilityIdentifier:@"thebutton"];
+
+        [control addSubview:field];
+//        [control addSubview:btn];
+
+        [tableViewCell.contentView addSubview:control];
+    } else {
+        [tableViewCell.contentView addSubview:_textField];
+    }
 
     return tableViewCell;
 }

--- a/Integration Tests/Tests/SLTextFieldTestViewController.m
+++ b/Integration Tests/Tests/SLTextFieldTestViewController.m
@@ -56,18 +56,11 @@
         _textField = [[UITextField alloc] initWithFrame:kTextFieldFrame];
 
         if (testCase == @selector(testSetTextWithinTableViewCell) ||
-            testCase == @selector(testSetTextClearsCurrentTextWithinTableViewCell)) {
+            testCase == @selector(testSetTextClearsCurrentTextWithinTableViewCell) ||
+            testCase == @selector(testSetTextWithinTableViewCellUnderControl)) {
             _tableView = [[UITableView alloc] initWithFrame:(CGRect){CGPointZero, CGSizeMake(320.0f, 44.0f)}];
             _tableView.dataSource = self;
             [view addSubview:_tableView];
-        } else if (testCase == @selector(testSetTextWithinTableViewCellUnderControl)) {
-            UIControl *control = [[UIControl alloc] initWithFrame:view.bounds];
-            control.userInteractionEnabled = YES;
-            control.accessibilityIdentifier = @"text field";
-//            _textField.userInteractionEnabled = YES;
-            [control addSubview:_textField];
-            [view addSubview:control];
-//            [view addSubview:_textField];
         } else {
             [view addSubview:_textField];
         }
@@ -110,6 +103,7 @@
     [super viewDidLoad];
 
     _textField.accessibilityLabel = @"test element";
+    _textField.autocorrectionType = UITextAutocorrectionTypeNo;
     _textField.borderStyle = UITextBorderStyleRoundedRect;
     if (self.testCase == @selector(testClearTextButton)) {
         _textField.clearButtonMode = UITextFieldViewModeAlways;
@@ -213,21 +207,7 @@
 
     if (self.testCase == @selector(testSetTextWithinTableViewCellUnderControl)) {
         UIControl *control = [[UIControl alloc] initWithFrame:self.view.bounds];
-        control.userInteractionEnabled = NO;
-
-        UITextField *field = [[UITextField alloc] initWithFrame:CGRectMake(10, 5, 25, 20)];
-
-        field.placeholder = @"FOO!";
-        field.accessibilityIdentifier = @"text field";
-        field.userInteractionEnabled = YES;
-
-//        UIButton *btn = [UIButton buttonWithType:UIButtonTypeInfoDark];
-//        [btn setFrame:CGRectMake(80, 0, 20, 20)];
-//        [btn setBackgroundColor:[UIColor blueColor]];
-//        [btn setAccessibilityIdentifier:@"thebutton"];
-
-        [control addSubview:field];
-//        [control addSubview:btn];
+        [control addSubview:_textField];
 
         [tableViewCell.contentView addSubview:control];
     } else {

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
@@ -449,9 +449,40 @@
 
 
 @implementation UIControl (SLAccessibilityHierarchy)
+
 - (BOOL)classForcesPresenceInAccessibilityHierarchy {
-    return YES;
+    BOOL forcesPresence = YES;
+    BOOL containedWithinTableView = NO;
+
+    id parent = self;
+    do {
+        parent = [parent slAccessibilityParent];
+
+        if ([parent isKindOfClass:[UITableView class]]) {
+            containedWithinTableView = YES;
+        }
+    } while (parent && !containedWithinTableView);
+
+    if (containedWithinTableView) {
+        NSMutableArray *children = [[self slChildAccessibilityElementsFavoringSubviews:YES] mutableCopy];
+        NSUInteger i = 0;
+        while (i < children.count) {
+            id child = children[i];
+
+            if ([child isKindOfClass:[UIControl class]]) {
+                forcesPresence = NO;
+                break;
+            }
+
+            [children addObjectsFromArray:[child slChildAccessibilityElementsFavoringSubviews:YES]];
+
+            ++i;
+        }
+    }
+
+    return forcesPresence;
 }
+
 @end
 
 

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
@@ -393,6 +393,7 @@
 }
 @end
 
+
 // On iOS 6, collection view cells themselves appear in the accessibility hierarchy.
 // On iOS 7, mock cells (instances of `UICollectionViewCellAccessibilityElement`) appear in the hierarchy instead.
 @implementation UICollectionViewCell (SLAccessibilityHierarchy)

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
@@ -393,7 +393,6 @@
 }
 @end
 
-
 // On iOS 6, collection view cells themselves appear in the accessibility hierarchy.
 // On iOS 7, mock cells (instances of `UICollectionViewCellAccessibilityElement`) appear in the hierarchy instead.
 @implementation UICollectionViewCell (SLAccessibilityHierarchy)


### PR DESCRIPTION
This is our attempt at a fix for #260. We verified that this doesn't break any existing tests, but we haven't tested all potential scenarios where this could alter existing, untested behavior.
