### PR TITLE
Support for a shouldMatchIfHidden property on SLElement

### DIFF
--- a/Sources/Classes/Internal/SLAccessibilityPath.m
+++ b/Sources/Classes/Internal/SLAccessibilityPath.m
@@ -220,6 +220,13 @@
 }
 
 - (NSArray *)rawAccessibilityPathToElement:(SLElement *)element favoringSubviews:(BOOL)favoringSubviews {
+    BOOL shouldMatchIfHidden = element.shouldMatchIfHidden;
+    BOOL elementIsHidden = [self elementIsHidden];
+
+    if (!shouldMatchIfHidden && [self isKindOfClass:[UIView class]] && elementIsHidden) {
+        return nil;
+    }
+
     for (NSObject *child in [self slChildAccessibilityElementsFavoringSubviews:favoringSubviews]) {
         NSArray *path = [child rawAccessibilityPathToElement:element favoringSubviews:favoringSubviews];
         if (path) {
@@ -232,6 +239,7 @@
     if ([element matchesObject:self]) {
         return [NSArray arrayWithObject:self];
     }
+
     return nil;
 }
 

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.h
@@ -64,6 +64,11 @@
  */
 - (BOOL)willAppearInAccessibilityHierarchy;
 
+/**
+ Returns a Boolean value that indicates whether the current element is hidden.
+ */
+- (BOOL)elementIsHidden;
+
 #pragma mark - Navigating the Accessibility Hierarchy
 /// -----------------------------------------------
 /// @name Navigating the Accessibility Hierarchy

--- a/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
+++ b/Sources/Classes/UIAutomation/User Interface Elements/NSObject+SLAccessibilityHierarchy.m
@@ -174,6 +174,10 @@
     return NO;
 }
 
+- (BOOL)elementIsHidden {
+    return [self isKindOfClass:[UIView class]] ? [(UIView *)self isHidden] : NO;
+}
+
 #pragma mark -Private methods
 
 - (BOOL)accessibilityAncestorPreventsPresenceInAccessibilityHierarchy {

--- a/Sources/Classes/UIAutomation/User Interface Elements/SLElement.h
+++ b/Sources/Classes/UIAutomation/User Interface Elements/SLElement.h
@@ -133,6 +133,14 @@
  */
 + (instancetype)anyElement;
 
+/**
+ By default, Subliminal only finds elements that are visible onscreen.
+ If you want to find an element that is *not* visible, set this flag to YES
+ */
+
+@property (nonatomic, assign) BOOL shouldMatchIfHidden;
+
+
 #pragma mark - Gestures and Actions
 /// ------------------------------------------
 /// @name Gestures and Actions


### PR DESCRIPTION
We have a few use cases where disregarding the `hidden` property of `UIView` results in an unwanted match: 

1) When the accessibility hierarchy has both hidden and non-hidden elements that match.
2) When there are matching hidden elements on an intermediate view when waiting for elements to appear on a subsequent view during an animation.

We have found it to be a real pain to debug. We've opened this pull request because we believe that the cases in which someone would want to match against an invisible element seem far-removed from a real-world use case.

Since this is a breaking change, we can set this to `YES` by default for backwards compatibility. A global flag to change this default behavior would be desirable as well.

+@justinseanmartin
